### PR TITLE
eslint: add eslint to nodereport

### DIFF
--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -1,0 +1,18 @@
+env:
+  node: true
+  es6: true
+
+rules:
+  indent: [2, 2]
+  quotes: [2, single]
+  no-trailing-spaces: 2
+  comma-spacing: [2, { before: false, after: true }]
+  eqeqeq: [2, always]
+  linebreak-style: [2, unix]
+  semi: [2, always]
+  no-console: 0
+  no-inner-declarations: 0
+  no-constant-condition: 0
+  no-regex-spaces: 0
+
+extends: eslint:recommended

--- a/demo/api_call.js
+++ b/demo/api_call.js
@@ -1,21 +1,21 @@
 // Example - generation of NodeReport via API call
 var nodereport = require('nodereport');
-var http = require("http");
+var http = require('http');
 
 var count = 0;
 
 function my_listener(request, response) {
   switch(count++) {
   case 0:
-    response.writeHead(200,{"Content-Type": "text/plain"});
-    response.write("\nRunning NodeReport API demo... refresh page to trigger NodeReport");
+    response.writeHead(200, {'Content-Type': 'text/plain'});
+    response.write('\nRunning NodeReport API demo... refresh page to trigger NodeReport');
     response.end();
     break;
   case 1:
-    response.writeHead(200,{"Content-Type": "text/plain"});
+    response.writeHead(200, {'Content-Type': 'text/plain'});
     // Call the nodereport module to trigger a NodeReport
     var filename = nodereport.triggerReport();
-    response.write("\n" + filename + " written - refresh page to close");
+    response.write('\n' + filename + ' written - refresh page to close');
     response.end();
     break;
   default:

--- a/demo/exception.js
+++ b/demo/exception.js
@@ -1,14 +1,14 @@
 // Example - generation of NodeReport on uncaught exception
-require('nodereport').setEvents("exception");
-var http = require("http");
+require('nodereport').setEvents('exception');
+var http = require('http');
 
 var count = 0;
 
 function my_listener(request, response) {
   switch(count++) {
   case 0:
-    response.writeHead(200,{"Content-Type": "text/plain"});
-    response.write("\nRunning NodeReport exception demo... refresh page to cause exception (application will terminate)");
+    response.writeHead(200, {'Content-Type': 'text/plain'});
+    response.write('\nRunning NodeReport exception demo... refresh page to cause exception (application will terminate)');
     response.end();
     break;
   default:
@@ -18,7 +18,7 @@ function my_listener(request, response) {
 
 function UserException(message) {
   this.message = message;
-  this.name = "UserException";
+  this.name = 'UserException';
 }
 
 var http_server = http.createServer(my_listener);

--- a/demo/fatalerror.js
+++ b/demo/fatalerror.js
@@ -1,5 +1,5 @@
 // Example - generation of Nodereport on fatal error (Javascript heap OOM)
-require('nodereport').setEvents("fatalerror");
+require('nodereport').setEvents('fatalerror');
 var http = require('http');
 
 var count = 0;
@@ -7,8 +7,8 @@ var count = 0;
 function my_listener(request, response) {
   switch(count++) {
   case 0:
-    response.writeHead(200,{"Content-Type": "text/plain"});
-    response.write("\nRunning NodeReport fatal error demo... refresh page to trigger excessive memory usage (application will terminate)");
+    response.writeHead(200, {'Content-Type': 'text/plain'});
+    response.write('\nRunning NodeReport fatal error demo... refresh page to trigger excessive memory usage (application will terminate)');
     response.end();
     break;
   case 1:
@@ -17,8 +17,10 @@ function my_listener(request, response) {
     while (true) {
       list.push(new MyRecord());
     }
+    /*eslint-disable no-unreachable */
     response.end();
     break;
+    /*eslint-enable no-unreachable */
   }
 }
 

--- a/demo/loop.js
+++ b/demo/loop.js
@@ -1,34 +1,35 @@
 // Example - geneation of Nodereport via signal for a looping application
-require('nodereport').setEvents("signal");
-var http = require("http");
+require('nodereport').setEvents('signal');
+var http = require('http');
 
 var count = 0;
 
 function my_listener(request, response) {
   switch(count++) {
   case 0:
-    response.writeHead(200,{"Content-Type": "text/plain"});
-    response.write("\nRunning NodeReport looping application demo. Node process ID = " + process.pid);
-    response.write("\n\nRefresh page to enter loop, then use 'kill -USR2 " + process.pid + "' to trigger NodeReport");
+    response.writeHead(200, {'Content-Type': 'text/plain'});
+    response.write('\nRunning NodeReport looping application demo. Node process ID = ' + process.pid);
+    response.write('\n\nRefresh page to enter loop, then use \'kill -USR2 ' + process.pid + '\' to trigger NodeReport');
     response.end();
     break;
   case 1:
-    console.log("loop.js: going to loop now, use 'kill -USR2 " + process.pid + "' to trigger NodeReport");
+    console.log('loop.js: going to loop now, use \'kill -USR2 ' + process.pid + '\' to trigger NodeReport');
     var list = [];
+    var j='';
     for (var i=0; i<10000000000; i++) {
-      for (var j=0; i<1000; i++) {
+      for (j=0; i<1000; i++) {
         list.push(new MyRecord());
       }
-      for (var j=0; i<1000; i++) {
+      for (j=0; i<1000; i++) {
         list[j].id += 1;
         list[j].account += 2;
       }
-      for (var j=0; i<1000; i++) {
+      for (j=0; i<1000; i++) {
         list.pop();
       }
     }
-    response.writeHead(200,{"Content-Type": "text/plain"});
-    response.write("\nNodeReport demo.... finished looping");
+    response.writeHead(200, {'Content-Type': 'text/plain'});
+    response.write('\nNodeReport demo.... finished looping');
     response.end();
     break;
   default:

--- a/package.json
+++ b/package.json
@@ -18,12 +18,15 @@
     "Richard Chamberlain <richard_chamberlain@uk.ibm.com> (https://github.com/rnchamberlain)"
   ],
   "scripts": {
-    "test": "tap test/test*.js"
+    "test": "npm run lint && npm run tap",
+    "tap": "tap --timeout 10 test/test*.js",
+    "lint": "eslint **/*.js"
   },
   "bugs": {
     "url": "https://github.com/nodejs/nodereport/issues"
   },
   "devDependencies": {
-    "tap": "^8.0.0"
+    "tap": "^8.0.0",
+    "eslint": "^3.13.1"
   }
 }

--- a/test/common.js
+++ b/test/common.js
@@ -61,9 +61,9 @@ exports.validate = (t, report, options) => {
         if (this.isWindows()) {
           // On Windows we need to strip double quotes from the command line in
           // the report, and escape backslashes in the regex comparison string.
-          t.match(nodeReportSection.replace(/"/g,''),
+          t.match(nodeReportSection.replace(/"/g, ''),
                   new RegExp('Command line: '
-                             + (options.commandline).replace(/\\/g,'\\\\')),
+                             + (options.commandline).replace(/\\/g, '\\\\')),
                   'Checking report contains expected command line');
         } else {
           t.match(nodeReportSection,

--- a/test/test-exception.js
+++ b/test/test-exception.js
@@ -4,7 +4,7 @@
 if (process.argv[2] === 'child') {
   require('../');
 
-  function myException(request, response) {
+  function myException() {
     const m = '*** test-exception.js: throwing uncaught Error';
     throw new Error(m);
   }
@@ -26,7 +26,7 @@ if (process.argv[2] === 'child') {
     tap.plan(4);
     // Verify exit code. Note that behaviour changed in V8 v5.4
     const v8_version = (process.versions.v8).match(/\d+/g);
-    if (v8_version[0] < 5 || (v8_version[0] == 5 && v8_version[1] < 4)) {
+    if (v8_version[0] < 5 || (v8_version[0] === 5 && v8_version[1] < 4)) {
       tap.equal(code, 0, 'Check for expected process exit code');
     } else {
       tap.equal(code, 1, 'Check for expected process exit code');


### PR DESCRIPTION
Adds eslint to be run with `npm test`. We should use eslintrc to remain consistent with the nodejs community such as nodejs/node and nodejs/citgm. This also allows you to use `npm run lint` or `npm run lint --- --fix` to fix linter errors. 

I have also shortened the timeout to ten seconds for the tap tests

Alternative to: https://github.com/nodejs/nodereport/pull/45