### PR TITLE
Rename nodereport module to node-report

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,7 @@
 
 # Package files
 NodeReport*.txt
+node-report*.txt
 npm-debug.log
 nodereport-*.tgz
 nodereport_test.log

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-# Contributing to nodereport
+# Contributing to node-report
 
 ## Code of Conduct
 
@@ -8,7 +8,7 @@ The [Node.js Code of Conduct][] applies to this repo.
 
 ## Code Contributions
 
-The nodereport project falls under the governance of the post-mortem
+The node-report project falls under the governance of the post-mortem
 working group which is documented in:
 https://github.com/nodejs/post-mortem/blob/master/GOVERNANCE.md
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,5 +1,5 @@
-# nodereport Project Governance
+# node-report Project Governance
 
-The nodereport project falls under the governance of the post-mortem
+The node-report project falls under the governance of the post-mortem
 working group which is documented in:
 https://github.com/nodejs/post-mortem/blob/master/GOVERNANCE.md.

--- a/LICENCE.md
+++ b/LICENCE.md
@@ -4,7 +4,7 @@ The MIT License (MIT)
 Copyright (c) 2016 node-report contributors
 --------------------------------------------------
 
-*nodereport contributors listed at <https://github.com/nodejs/nodereport/blob/master/AUTHORS>*
+*nodereport contributors listed in <https://github.com/nodejs/nodereport/blob/master/package.json>*
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 

--- a/LICENCE.md
+++ b/LICENCE.md
@@ -1,7 +1,7 @@
 The MIT License (MIT)
 =====================
 
-Copyright (c) 2016 nodereport contributors
+Copyright (c) 2016 node-report contributors
 --------------------------------------------------
 
 *nodereport contributors listed at <https://github.com/nodejs/nodereport/blob/master/AUTHORS>*

--- a/MAINTAINER.md
+++ b/MAINTAINER.md
@@ -1,15 +1,15 @@
-# Instructions for maintainers of the nodereport project
+# Instructions for maintainers of the node-report project
 
 ## Publishing to the npm registry
 
-The nodereport project is published as an npm native module
+The node-report project is published as an npm native module
 
 For each publish to npm:
 
  - update the version property in the package.json file, incrementing the major, minor and patch level as appropriate 
  - update the CHANGES.md file with a list of commits since last release
- - commit CHANGES.md and package.json to nodereport master branch
+ - commit CHANGES.md and package.json to node-report master branch
  - tag commit with an annotated tag
- - git checkout and npm publish the nodereport package
+ - git checkout and npm publish the node-report package
 
 Suggested tooling is the slt-release script documented here: https://github.com/strongloop/strong-tools

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# nodereport
+# node-report
 
 Delivers a human-readable diagnostic summary, written to file.
 
@@ -14,45 +14,45 @@ Supports Node.js v4, v6 and v7 on Linux, MacOS, Windows and AIX.
 ## Usage
 
 ```bash
-npm install nodereport
-node -r nodereport app.js
+npm install node-report
+node -r node-report app.js
 ```
-A NodeReport will be triggered automatically on unhandled exceptions and fatal
+A report will be triggered automatically on unhandled exceptions and fatal
 error events (for example out of memory errors), and can also be triggered
 by sending a USR2 signal to a Node.js process (AIX/Linux/MacOS only).
 
-A NodeReport can also be triggered via an API call from a JavaScript
+A report can also be triggered via an API call from a JavaScript
 application.
 
 ```js
-var nodereport = require('nodereport');
+var nodereport = require('node-report');
 nodereport.triggerReport();
 ```
 The API can be used without adding the automatic exception and fatal error
 hooks and the signal handler, as follows:
 
 ```js
-var nodereport = require('nodereport/api');
+var nodereport = require('node-report/api');
 nodereport.triggerReport();
 ```
 
-Content of the NodeReport consists of a header section containing the event
+Content of the report consists of a header section containing the event
 type, date, time, PID and Node version, sections containing JavaScript and
 native stack traces, a section containing V8 heap information, a section
 containing libuv handle information and an OS platform information section
-showing CPU and memory usage and system limits. An example NodeReport can be
+showing CPU and memory usage and system limits. An example report can be
 triggered using the Node.js REPL:
 
 ```
 $ node
-> nodereport = require('nodereport')
+> nodereport = require('node-report')
 > nodereport.triggerReport()
-Writing Node.js report to file: NodeReport.20161020.091102.8480.001.txt
+Writing Node.js report to file: node-report.20161020.091102.8480.001.txt
 Node.js report completed
 >
 ```
 
-When a NodeReport is triggered, start and end messages are issued to stderr
+When a report is triggered, start and end messages are issued to stderr
 and the filename of the report is returned to the caller. The default filename
 includes the date, time, PID and a sequence number. Alternatively, a filename
 can be specified as a parameter on the `triggerReport()` call.
@@ -66,14 +66,14 @@ nodereport.triggerReport("myReportName");
 Additional configuration is available using the following APIs:
 
 ```js
-nodereport.setEvents("exception+fatalerror+signal+apicall");
-nodereport.setSignal("SIGUSR2|SIGQUIT");
-nodereport.setFileName("stdout|stderr|<filename>");
-nodereport.setDirectory("<full path>");
-nodereport.setVerbose("yes|no");
+setEvents("exception+fatalerror+signal+apicall");
+setSignal("SIGUSR2|SIGQUIT");
+setFileName("stdout|stderr|<filename>");
+setDirectory("<full path>");
+setVerbose("yes|no");
 ```
 
-Configuration on module Initialization is also available via environment variables:
+Configuration on module initialization is also available via environment variables:
 
 ```bash
 export NODEREPORT_EVENTS=exception+fatalerror+signal+apicall
@@ -85,14 +85,14 @@ export NODEREPORT_VERBOSE=yes|no
 
 ## Examples
 
-To see examples of NodeReports generated from these events you can run the
-demonstration applications provided in the nodereport github repository. These are
+To see examples of reports generated from these events you can run the
+demonstration applications provided in the node-report github repository. These are
 Node.js applications which will prompt you to trigger the required event.
 
-1. `api.js` - NodeReport triggered by JavaScript API call.
-2. `exception.js` - NodeReport triggered by unhandled exception.
-3. `fatalerror.js` - NodeReport triggered by fatal error on JavaScript heap out of memory.
-4. `loop.js` - looping application, NodeReport triggered using kill `-USR2 <pid>`.
+1. `api.js` - report triggered by JavaScript API call.
+2. `exception.js` - report triggered by unhandled exception.
+3. `fatalerror.js` - report triggered by fatal error on JavaScript heap out of memory.
+4. `loop.js` - looping application, report triggered using kill `-USR2 <pid>`.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -66,11 +66,12 @@ nodereport.triggerReport("myReportName");
 Additional configuration is available using the following APIs:
 
 ```js
-setEvents("exception+fatalerror+signal+apicall");
-setSignal("SIGUSR2|SIGQUIT");
-setFileName("stdout|stderr|<filename>");
-setDirectory("<full path>");
-setVerbose("yes|no");
+var nodereport = require('node-report/api');
+nodereport.setEvents("exception+fatalerror+signal+apicall");
+nodereport.setSignal("SIGUSR2|SIGQUIT");
+nodereport.setFileName("stdout|stderr|<filename>");
+nodereport.setDirectory("<full path>");
+nodereport.setVerbose("yes|no");
 ```
 
 Configuration on module initialization is also available via environment variables:

--- a/demo/api_call.js
+++ b/demo/api_call.js
@@ -1,5 +1,5 @@
-// Example - generation of NodeReport via API call
-var nodereport = require('nodereport');
+// Example - generation of report via API call
+var nodereport = require('node-report');
 var http = require("http");
 
 var count = 0;
@@ -8,12 +8,12 @@ function my_listener(request, response) {
   switch(count++) {
   case 0:
     response.writeHead(200,{"Content-Type": "text/plain"});
-    response.write("\nRunning NodeReport API demo... refresh page to trigger NodeReport");
+    response.write("\nRunning node-report API demo... refresh page to trigger NodeReport");
     response.end();
     break;
   case 1:
     response.writeHead(200,{"Content-Type": "text/plain"});
-    // Call the nodereport module to trigger a NodeReport
+    // Call the node-report module to trigger a report
     var filename = nodereport.triggerReport();
     response.write("\n" + filename + " written - refresh page to close");
     response.end();

--- a/demo/api_call.js
+++ b/demo/api_call.js
@@ -8,7 +8,7 @@ function my_listener(request, response) {
   switch(count++) {
   case 0:
     response.writeHead(200,{"Content-Type": "text/plain"});
-    response.write("\nRunning node-report API demo... refresh page to trigger NodeReport");
+    response.write("\nRunning node-report API demo... refresh page to trigger report");
     response.end();
     break;
   case 1:

--- a/demo/exception.js
+++ b/demo/exception.js
@@ -1,5 +1,5 @@
-// Example - generation of NodeReport on uncaught exception
-require('nodereport').setEvents("exception");
+// Example - generation of report on uncaught exception
+require('node-report').setEvents("exception");
 var http = require("http");
 
 var count = 0;
@@ -8,7 +8,7 @@ function my_listener(request, response) {
   switch(count++) {
   case 0:
     response.writeHead(200,{"Content-Type": "text/plain"});
-    response.write("\nRunning NodeReport exception demo... refresh page to cause exception (application will terminate)");
+    response.write("\nRunning node-report exception demo... refresh page to cause exception (application will terminate)");
     response.end();
     break;
   default:

--- a/demo/fatalerror.js
+++ b/demo/fatalerror.js
@@ -1,5 +1,5 @@
-// Example - generation of Nodereport on fatal error (Javascript heap OOM)
-require('nodereport').setEvents("fatalerror");
+// Example - generation of report on fatal error (Javascript heap OOM)
+require('node-report').setEvents("fatalerror");
 var http = require('http');
 
 var count = 0;
@@ -8,7 +8,7 @@ function my_listener(request, response) {
   switch(count++) {
   case 0:
     response.writeHead(200,{"Content-Type": "text/plain"});
-    response.write("\nRunning NodeReport fatal error demo... refresh page to trigger excessive memory usage (application will terminate)");
+    response.write("\nRunning node-report fatal error demo... refresh page to trigger excessive memory usage (application will terminate)");
     response.end();
     break;
   case 1:

--- a/demo/loop.js
+++ b/demo/loop.js
@@ -9,11 +9,11 @@ function my_listener(request, response) {
   case 0:
     response.writeHead(200,{"Content-Type": "text/plain"});
     response.write("\nRunning node-report looping application demo. Node process ID = " + process.pid);
-    response.write("\n\nRefresh page to enter loop, then use 'kill -USR2 " + process.pid + "' to trigger NodeReport");
+    response.write("\n\nRefresh page to enter loop, then use 'kill -USR2 " + process.pid + "' to trigger report");
     response.end();
     break;
   case 1:
-    console.log("loop.js: going to loop now, use 'kill -USR2 " + process.pid + "' to trigger NodeReport");
+    console.log("loop.js: going to loop now, use 'kill -USR2 " + process.pid + "' to trigger report");
     var list = [];
     for (var i=0; i<10000000000; i++) {
       for (var j=0; i<1000; i++) {

--- a/demo/loop.js
+++ b/demo/loop.js
@@ -1,5 +1,5 @@
-// Example - geneation of Nodereport via signal for a looping application
-require('nodereport').setEvents("signal");
+// Example - generation of report via signal for a looping application
+require('node-report').setEvents("signal");
 var http = require("http");
 
 var count = 0;
@@ -8,7 +8,7 @@ function my_listener(request, response) {
   switch(count++) {
   case 0:
     response.writeHead(200,{"Content-Type": "text/plain"});
-    response.write("\nRunning NodeReport looping application demo. Node process ID = " + process.pid);
+    response.write("\nRunning node-report looping application demo. Node process ID = " + process.pid);
     response.write("\n\nRefresh page to enter loop, then use 'kill -USR2 " + process.pid + "' to trigger NodeReport");
     response.end();
     break;
@@ -28,7 +28,7 @@ function my_listener(request, response) {
       }
     }
     response.writeHead(200,{"Content-Type": "text/plain"});
-    response.write("\nNodeReport demo.... finished looping");
+    response.write("\nnode-report demo.... finished looping");
     response.end();
     break;
   default:

--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-// Main module entry point for nodereport
+// Main module entry point for node-report
 
 const api = require('./api');
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "node-report",
   "version": "1.0.7",
-  "description": "Diagnostic Report for Node",
+  "description": "Diagnostic Report for Node.js",
   "homepage": "https://github.com/nodejs/node-report#readme",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
-  "name": "nodereport",
+  "name": "node-report",
   "version": "1.0.7",
-  "description": "Diagnostic NodeReport",
-  "homepage": "https://github.com/nodejs/nodereport#readme",
+  "description": "Diagnostic Report for Node",
+  "homepage": "https://github.com/nodejs/node-report#readme",
   "repository": {
     "type": "git",
-    "url": "https://github.com/nodejs/nodereport.git"
+    "url": "https://github.com/nodejs/node-report.git"
   },
   "engines": {
     "node": ">=4.0.0"
@@ -21,7 +21,7 @@
     "test": "tap test/test*.js"
   },
   "bugs": {
-    "url": "https://github.com/nodejs/nodereport/issues"
+    "url": "https://github.com/nodejs/node-report/issues"
   },
   "devDependencies": {
     "tap": "^8.0.0"

--- a/src/node_report.cc
+++ b/src/node_report.cc
@@ -85,7 +85,7 @@ static void PrintLoadedLibraries(FILE* fp, Isolate* isolate);
 static void WriteInteger(FILE* fp, size_t value);
 
 // Global variables
-static int seq = 0;  // sequence number for NodeReport filenames
+static int seq = 0;  // sequence number for report filenames
 const char* v8_states[] = {"JS", "GC", "COMPILER", "OTHER", "EXTERNAL", "IDLE"};
 static bool report_active = false; // recursion protection
 static char report_filename[NR_MAXNAME + 1] = "";
@@ -99,12 +99,12 @@ static struct tm loadtime_tm_struct; // module load time
 #endif
 
 /*******************************************************************************
- * Functions to process nodereport configuration options:
+ * Functions to process node-report configuration options:
  *   Trigger event selection
  *   Core dump yes/no switch
  *   Trigger signal selection
- *   NodeReport filename
- *   NodeReport directory
+ *   Report filename
+ *   Report directory
  *   Verbose mode
  ******************************************************************************/
 unsigned int ProcessNodeReportEvents(const char* args) {
@@ -125,7 +125,7 @@ unsigned int ProcessNodeReportEvents(const char* args) {
       event_flags |= NR_APICALL;
       cursor += sizeof("apicall") - 1;
     } else {
-      fprintf(stderr, "Unrecognised argument for nodereport events option: %s\n", cursor);
+      fprintf(stderr, "Unrecognised argument for node-report events option: %s\n", cursor);
       return 0;
     }
     if (*cursor == '+') {
@@ -140,7 +140,7 @@ unsigned int ProcessNodeReportSignal(const char* args) {
   return 0; // no-op on Windows
 #else
   if (strlen(args) == 0) {
-    fprintf(stderr, "Missing argument for nodereport signal option\n");
+    fprintf(stderr, "Missing argument for node-report signal option\n");
   } else {
     // Parse the supplied switch
     if (!strncmp(args, "SIGUSR2", sizeof("SIGUSR2") - 1)) {
@@ -148,7 +148,7 @@ unsigned int ProcessNodeReportSignal(const char* args) {
     } else if (!strncmp(args, "SIGQUIT", sizeof("SIGQUIT") - 1)) {
       return SIGQUIT;
     } else {
-      fprintf(stderr, "Unrecognised argument for nodereport signal option: %s\n", args);
+      fprintf(stderr, "Unrecognised argument for node-report signal option: %s\n", args);
     }
   }
   return SIGUSR2;  // Default signal is SIGUSR2
@@ -157,11 +157,11 @@ unsigned int ProcessNodeReportSignal(const char* args) {
 
 void ProcessNodeReportFileName(const char* args) {
   if (strlen(args) == 0) {
-    fprintf(stderr, "Missing argument for nodereport filename option\n");
+    fprintf(stderr, "Missing argument for node-report filename option\n");
     return;
   }
   if (strlen(args) > NR_MAXNAME) {
-    fprintf(stderr, "Supplied nodereport filename too long (max %d characters)\n", NR_MAXNAME);
+    fprintf(stderr, "Supplied node-report filename too long (max %d characters)\n", NR_MAXNAME);
     return;
   }
   snprintf(report_filename, sizeof(report_filename), "%s", args);
@@ -169,11 +169,11 @@ void ProcessNodeReportFileName(const char* args) {
 
 void ProcessNodeReportDirectory(const char* args) {
   if (strlen(args) == 0) {
-    fprintf(stderr, "Missing argument for nodereport directory option\n");
+    fprintf(stderr, "Missing argument for node-report directory option\n");
     return;
   }
   if (strlen(args) > NR_MAXPATH) {
-    fprintf(stderr, "Supplied nodereport directory path too long (max %d characters)\n", NR_MAXPATH);
+    fprintf(stderr, "Supplied node-report directory path too long (max %d characters)\n", NR_MAXPATH);
     return;
   }
   snprintf(report_directory, sizeof(report_directory), "%s", args);
@@ -181,7 +181,7 @@ void ProcessNodeReportDirectory(const char* args) {
 
 unsigned int ProcessNodeReportVerboseSwitch(const char* args) {
   if (strlen(args) == 0) {
-    fprintf(stderr, "Missing argument for nodereport verbose switch option\n");
+    fprintf(stderr, "Missing argument for node-report verbose switch option\n");
     return 0;
   }
   // Parse the supplied switch
@@ -190,7 +190,7 @@ unsigned int ProcessNodeReportVerboseSwitch(const char* args) {
   } else if (!strncmp(args, "no", sizeof("no") - 1) || !strncmp(args, "false", sizeof("false") - 1)) {
     return 0;
   } else {
-    fprintf(stderr, "Unrecognised argument for nodereport verbose switch option: %s\n", args);
+    fprintf(stderr, "Unrecognised argument for node-report verbose switch option: %s\n", args);
   }
   return 0;  // Default is verbose mode off
 }
@@ -287,7 +287,7 @@ void SetVersionString(Isolate* isolate) {
 }
 
 /*******************************************************************************
- * Function to save the nodereport module load time value
+ * Function to save the node-report module load time value
  *******************************************************************************/
 void SetLoadTime() {
 #ifdef _WIN32
@@ -360,17 +360,17 @@ void SetCommandLine() {
 }
 
 /*******************************************************************************
- * Main API function to write a NodeReport to file.
+ * Main API function to write a report to file.
  *
  * Parameters:
  *   Isolate* isolate
  *   DumpEvent event
  *   const char* message
  *   const char* location
- *   char* name - in/out - returns the NodeReport filename
+ *   char* name - in/out - returns the report filename
  ******************************************************************************/
 void TriggerNodeReport(Isolate* isolate, DumpEvent event, const char* message, const char* location, char* name) {
-  // Recursion check for NodeReport in progress, bail out
+  // Recursion check for report in progress, bail out
   if (report_active) return;
   report_active = true;
 
@@ -387,7 +387,7 @@ void TriggerNodeReport(Isolate* isolate, DumpEvent event, const char* message, c
   pid_t pid = getpid();
 #endif
 
-  // Determine the required NodeReport filename. In order of priority:
+  // Determine the required report filename. In order of priority:
   //   1) supplied on API 2) configured on startup 3) default generated
   char filename[NR_MAXNAME + 1] = "";
   if (name != nullptr && strlen(name) > 0) {
@@ -397,8 +397,8 @@ void TriggerNodeReport(Isolate* isolate, DumpEvent event, const char* message, c
     // File name was supplied via start-up option, use that
     snprintf(filename, sizeof(filename), "%s", report_filename);
   } else {
-    // Construct the NodeReport filename, with timestamp, pid and sequence number
-    snprintf(filename, sizeof(filename), "%s", "NodeReport");
+    // Construct the report filename, with timestamp, pid and sequence number
+    snprintf(filename, sizeof(filename), "%s", "node-report");
     seq++;
 #ifdef _WIN32
     snprintf(&filename[strlen(filename)], sizeof(filename) - strlen(filename),
@@ -415,7 +415,7 @@ void TriggerNodeReport(Isolate* isolate, DumpEvent event, const char* message, c
 #endif
   }
 
-  // Open the NodeReport file stream for writing. Supports stdout/err, user-specified or (default) generated name
+  // Open the report file stream for writing. Supports stdout/err, user-specified or (default) generated name
   FILE* fp = nullptr;
   if (!strncmp(filename, "stdout", sizeof("stdout") - 1)) {
     fp = stdout;
@@ -447,10 +447,10 @@ void TriggerNodeReport(Isolate* isolate, DumpEvent event, const char* message, c
     }
   }
 
-  // File stream opened OK, now start printing the NodeReport content, starting with the title
+  // File stream opened OK, now start printing the report content, starting with the title
   // and header information (event, filename, timestamp and pid)
   fprintf(fp, "================================================================================\n");
-  fprintf(fp, "==== NodeReport ================================================================\n");
+  fprintf(fp, "==== Node Report ===============================================================\n");
   fprintf(fp, "\nEvent: %s, location: \"%s\"\n", message, location);
   fprintf(fp, "Filename: %s\n", filename);
 
@@ -522,7 +522,7 @@ void TriggerNodeReport(Isolate* isolate, DumpEvent event, const char* message, c
 
   fprintf(stderr, "Node.js report completed\n");
   if (name != nullptr) {
-    snprintf(name, NR_MAXNAME + 1, "%s", filename);  // return the NodeReport file name
+    snprintf(name, NR_MAXNAME + 1, "%s", filename);  // return the report file name
   }
   report_active = false;
 }
@@ -546,9 +546,9 @@ static void PrintVersionInformation(FILE* fp, Isolate* isolate) {
   // Print Node.js and deps component versions
   fprintf(fp, "\n%s", version_string.c_str());
 
-  // Print NodeReport version
-  // e.g. NodeReport version: 1.0.6 (built against Node.js v6.9.1)
-  fprintf(fp, "\nNodeReport version: %s (built against Node.js v%s)\n",
+  // Print node-report module version
+  // e.g. node-report version: 1.0.6 (built against Node.js v6.9.1)
+  fprintf(fp, "\nnode-report version: %s (built against Node.js v%s)\n",
           NODEREPORT_VERSION, NODE_VERSION_STRING);
 
   // Print operating system and machine information (Windows)
@@ -820,7 +820,7 @@ void PrintNativeStack(FILE* fp) {
     return;
   }
 
-  // Print the native frames, omitting the top 3 frames as they are in nodereport code
+  // Print the native frames, omitting the top 3 frames as they are in node-report code
   // backtrace_symbols_fd(frames, size, fileno(fp));
   for (int i = 2; i < size; i++) {
     // print frame index and instruction address

--- a/src/node_report.h
+++ b/src/node_report.h
@@ -23,7 +23,7 @@ using v8::Value;
 using v8::StackTrace;
 using v8::StackFrame;
 
-// Bit-flags for NodeReport trigger options
+// Bit-flags for node-report trigger options
 #define NR_EXCEPTION  0x01
 #define NR_FATALERROR 0x02
 #define NR_SIGNAL     0x04

--- a/test/common.js
+++ b/test/common.js
@@ -3,7 +3,7 @@
 const fs = require('fs');
 
 const REPORT_SECTIONS = [
-  'NodeReport',
+  'Node Report',
   'JavaScript Stack Trace',
   'JavaScript Heap',
   'System Information'
@@ -12,8 +12,8 @@ const REPORT_SECTIONS = [
 const reNewline = '(?:\\r*\\n)';
 
 exports.findReports = (pid) => {
-  // Default filenames are of the form NodeReport.<date>.<time>.<pid>.<seq>.txt
-  const format = '^NodeReport\\.\\d+\\.\\d+\\.' + pid + '\\.\\d+\\.txt$';
+  // Default filenames are of the form node-report.<date>.<time>.<pid>.<seq>.txt
+  const format = '^node-report\\.\\d+\\.\\d+\\.' + pid + '\\.\\d+\\.txt$';
   const filePattern = new RegExp(format);
   const files = fs.readdirSync('.');
   return files.filter((file) => filePattern.test(file));
@@ -49,17 +49,17 @@ exports.validate = (t, report, options) => {
                 'Checking report contains ' + section + ' section');
       });
 
-      // Check NodeReport header section
-      const nodeReportSection = getSection(reportContents, 'NodeReport');
+      // Check report header section
+      const nodeReportSection = getSection(reportContents, 'Node Report');
       t.match(nodeReportSection, new RegExp('Process ID: ' + pid),
-              'NodeReport section contains expected process ID');
+              'Node Report header section contains expected process ID');
       if (options && options.expectNodeVersion === false) {
         t.match(nodeReportSection, /Unable to determine Node.js version/,
-                'NodeReport section contains expected Node.js version');
+                'Node Report header section contains expected Node.js version');
       } else {
         t.match(nodeReportSection,
                 new RegExp('Node.js version: ' + process.version),
-                'NodeReport section contains expected Node.js version');
+                'Node Report header section contains expected Node.js version');
       }
       if (options && options.commandline) {
         if (this.isWindows()) {
@@ -80,24 +80,23 @@ exports.validate = (t, report, options) => {
           if (expectedVersions.indexOf(c) === -1) {
             t.notMatch(nodeReportSection,
                        new RegExp(c + ': ' + process.versions[c]),
-                       'NodeReport section does not contain ' + c + ' version');
+                       'Node Report header section does not contain ' + c + ' version');
           } else {
             t.match(nodeReportSection,
                     new RegExp(c + ': ' + process.versions[c]),
-                    'NodeReport section contains expected ' + c + ' version');
+                    'Node Report header section contains expected ' + c + ' version');
           }
         }
       });
       const nodereportMetadata = require('../package.json');
       t.match(nodeReportSection,
-              new RegExp('NodeReport version: ' + nodereportMetadata.version),
-              'NodeReport section contains expected NodeReport version');
+              new RegExp('node-report version: ' + nodereportMetadata.version),
+              'Node Report header section contains expected NodeReport version');
       const sysInfoSection = getSection(reportContents, 'System Information');
-      // Find a line which ends with "/api.node" or "\api.node"
-      // (Unix or Windows paths) to see if the library for node report was
-      // loaded.
+      // Find a line which ends with "/api.node" or "\api.node" (Unix or
+      // Windows paths) to see if the library for node report was loaded.
       t.match(sysInfoSection, /  .*(\/|\\)api\.node/,
-        'System Information section contains nodereport library.');
+        'System Information section contains node-report library.');
     });
   });
 };

--- a/test/test-api-bad-processobj.js
+++ b/test/test-api-bad-processobj.js
@@ -1,6 +1,6 @@
 'use strict';
 
-// Testcase to check NodeReport succeeds if process.versions is damaged
+// Testcase to check report succeeds if process.versions is damaged
 if (process.argv[2] === 'child') {
   // Tamper with the process object
   Object.defineProperty(process, 'versions', {get() { throw 'boom'; }});

--- a/test/test-api-bad-processversion.js
+++ b/test/test-api-bad-processversion.js
@@ -1,6 +1,6 @@
 'use strict';
 
-// Testcase to check NodeReport succeeds if process.version is damaged
+// Testcase to check report succeeds if process.version is damaged
 if (process.argv[2] === 'child') {
   // Tamper with the process object
   delete process['version'];

--- a/test/test-api-bad-processversions.js
+++ b/test/test-api-bad-processversions.js
@@ -1,6 +1,6 @@
 'use strict';
 
-// Testcase to check NodeReport succeeds if part of process.versions is damaged
+// Testcase to check report succeeds if part of process.versions is damaged
 if (process.argv[2] === 'child') {
   // Tamper with the process object
   Object.defineProperty(process.versions, 'uv', {get() { throw 'boom'; }});

--- a/test/test-api-nohooks.js
+++ b/test/test-api-nohooks.js
@@ -1,7 +1,7 @@
 'use strict';
 
-// Testcase to produce NodeReport via API call, using the no-hooks/no-signal
-// interface - i.e. require('nodereport/api')
+// Testcase to produce report via API call, using the no-hooks/no-signal
+// interface - i.e. require('node-report/api')
 if (process.argv[2] === 'child') {
   const nodereport = require('../api');
   nodereport.triggerReport();

--- a/test/test-api-noversioninfo.js
+++ b/test/test-api-noversioninfo.js
@@ -1,6 +1,6 @@
 'use strict';
 
-// Testcase to check NodeReport succeeds if both process.version and
+// Testcase to check report succeeds if both process.version and
 // process.versions are damaged
 if (process.argv[2] === 'child') {
   // Tamper with the process object

--- a/test/test-api.js
+++ b/test/test-api.js
@@ -1,6 +1,6 @@
 'use strict';
 
-// Testcase to produce NodeReport via API call
+// Testcase to produce report via API call
 if (process.argv[2] === 'child') {
   const nodereport = require('../');
   nodereport.triggerReport();

--- a/test/test-exception.js
+++ b/test/test-exception.js
@@ -1,6 +1,6 @@
 'use strict';
 
-// Testcase to produce NodeReport on uncaught exception
+// Testcase to produce report on uncaught exception
 if (process.argv[2] === 'child') {
   require('../');
 

--- a/test/test-fatal-error.js
+++ b/test/test-fatal-error.js
@@ -1,6 +1,6 @@
 'use strict';
 
-// Testcase to produce NodeReport on fatal error (javascript heap OOM)
+// Testcase to produce report on fatal error (javascript heap OOM)
 if (process.argv[2] === 'child') {
   require('../');
 

--- a/test/test-signal.js
+++ b/test/test-signal.js
@@ -1,6 +1,6 @@
 'use strict';
 
-// Testcase to produce NodeReport on signal interrupting a js busy-loop,
+// Testcase to produce report on signal interrupting a js busy-loop,
 // showing it is interruptible.
 if (process.argv[2] === 'child') {
   require('../');


### PR DESCRIPTION
Provides code, documentation, test and demo changes required for the migration of the nodereport project to node-report. The main changes are in the build, tests and demos that use the module name, and in the name of the report file. Remaining changes are mostly in comments. Internal variable and macro names are not changed.

This supercedes https://github.com/nodejs/node-report/pull/43

CI: https://ci.nodejs.org/view/post-mortem/job/nodereport-continuous-integration/44/