### PR TITLE
makefile: add makefile to linter c++ code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,9 @@
 *.project
 *.cproject
 
+# Linter files
+cpplint.py
+
 # Build directories
 /build/
 /node_modules/

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,13 @@
+PYTHON ?= python
+
+all: lint
+
+lint: cpplint
+
+cpplint.py:
+	curl -o cpplint.py "https://raw.githubusercontent.com/nodejs/node/master/tools/cpplint.py"
+
+cpplint: cpplint.py
+	python cpplint.py **/*.cc **/*.h
+
+.PHONY: all cpplint lint r

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "Richard Chamberlain <richard_chamberlain@uk.ibm.com> (https://github.com/rnchamberlain)"
   ],
   "scripts": {
-    "test": "tap test/test*.js"
+    "test": "make lint && tap test/test*.js"
   },
   "bugs": {
     "url": "https://github.com/nodejs/nodereport/issues"


### PR DESCRIPTION
This can be run using `make linter` but will also be executed by
default with the `npm test` command