### PR TITLE
mac: Fix compilation errors against Node > v5

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -1,4 +1,7 @@
 {
+  'variables': {
+        'node_major_version': '<!(node -e "console.log(process.version.substr(1,1))")',
+  },
   "targets": [
     {
       "target_name": "api",
@@ -13,7 +16,7 @@
           "libraries": [ "dbghelp.lib", "Netapi32.lib", "PsApi.lib" ],
           "dll_files": [ "dbghelp.dll", "Netapi32.dll", "PsApi.dll" ],
         }],
-        ["OS=='mac'", {
+        ["OS=='mac' and node_major_version > 5", {
           "xcode_settings": {
             'CLANG_CXX_LIBRARY': 'libc++',
             'CLANG_CXX_LANGUAGE_STANDARD':'c++11',

--- a/binding.gyp
+++ b/binding.gyp
@@ -1,7 +1,4 @@
 {
-  'variables': {
-        'node_major_version': '<!(node -e "console.log(process.version.substr(1,1))")',
-  },
   "targets": [
     {
       "target_name": "api",
@@ -15,12 +12,6 @@
         ["OS=='win'", {
           "libraries": [ "dbghelp.lib", "Netapi32.lib", "PsApi.lib" ],
           "dll_files": [ "dbghelp.dll", "Netapi32.dll", "PsApi.dll" ],
-        }],
-        ["OS=='mac' and node_major_version > 5", {
-          "xcode_settings": {
-            'CLANG_CXX_LIBRARY': 'libc++',
-            'CLANG_CXX_LANGUAGE_STANDARD':'c++11',
-          }
         }],
       ],
       "defines": [

--- a/src/node_report.cc
+++ b/src/node_report.cc
@@ -264,26 +264,21 @@ void SetVersionString(Isolate* isolate) {
   // (ares: 1.10.1-DEV, http_parser: 2.7.0, icu: 57.1, modules: 48,
   //  openssl: 1.0.2j, uv: 1.9.1, v8: 5.1.281.84, zlib: 1.2.8)
   const size_t wrap = 80;
-  size_t line_length = 1;
   version_string += "(";
+  const char* separator = "";
+  std::string versions = "";
   for (auto it : comp_versions) {
-    std::string component_name = it.first;
-    std::string component_version = it.second;
-    size_t length = component_name.length() + component_version.length() + 2;
-    if (line_length + length + 1 >= wrap) {
-      version_string += "\n ";
-      line_length = 1;
+    std::string comp_version_string = it.first;
+    comp_version_string += ": ";
+    comp_version_string += it.second;
+    versions += separator;
+    if (wrap - (versions.length() % wrap) < comp_version_string.length()) {
+      versions += "\n ";
     }
-    version_string += component_name;
-    version_string += ": ";
-    version_string += component_version;
-    line_length += length;
-    if (it != *std::prev(comp_versions.end())) {
-      version_string += ", ";
-      line_length += 2;
-    }
+    separator = ", ";
+    versions += comp_version_string;
   }
-  version_string += ")\n";
+  version_string += versions + ")\n";
 }
 
 /*******************************************************************************


### PR DESCRIPTION
Only use libc++ on Mac when Node itself supports it. (Node 6 and higher.)
Don’t use std::prev as that requires libc++

This should resolve issue #55.

CI runs on Node v4:
https://ci.nodejs.org/view/post-mortem/job/nodereport-continuous-integration/46/
and Node v6:
https://ci.nodejs.org/view/post-mortem/job/nodereport-continuous-integration/47/
OSX builds passed for both of those.