### PR TITLE
aix: improve readability of os version

### DIFF
--- a/src/node_report.cc
+++ b/src/node_report.cc
@@ -696,8 +696,13 @@ static void PrintVersionInformation(std::ostream& out) {
   // Print operating system and machine information (Unix/OSX)
   struct utsname os_info;
   if (uname(&os_info) == 0) {
+#if defined(_AIX)
+    out << "\nOS version: " << os_info.sysname << " " << os_info.version << "."
+        << os_info.release << "\n";
+#else
     out << "\nOS version: " << os_info.sysname << " " << os_info.release << " "
         << os_info.version << "\n";
+#endif
 #if defined(__GLIBC__)
     out << "(glibc: "<< __GLIBC__ << "." << __GLIBC_MINOR__ << ")\n";
 #endif

--- a/test/test-os-version.js
+++ b/test/test-os-version.js
@@ -1,0 +1,27 @@
+'use strict';
+
+// Testcase for validating reported OS version
+
+const common = require('./common.js');
+const nodereport = require('../');
+const os = require('os');
+const tap = require('tap');
+
+const os_map = {
+  'aix': 'AIX',
+  'darwin': 'Darwin',
+  'linux': 'Linux',
+  'win32': 'Windows',
+};
+const os_name = os_map[os.platform()];
+const report_str = nodereport.getReport();
+const version_str = report_str.match(/OS version: .*(?:\r*\n)/);
+if (common.isWindows()) {
+  tap.match(version_str, new RegExp('OS version: ' + os_name), 'Checking OS version');
+} else if (common.isAIX() && !os.release().includes('.')) {
+  // For Node.js prior to os.release() fix for AIX:  https://github.com/nodejs/node/pull/10245
+  tap.match(version_str, new RegExp('OS version: ' + os_name + ' \\d+.' + os.release()), 'Checking OS version');
+} else if (!common.isWindows()) {
+  tap.match(version_str, new RegExp('OS version: ' + os_name + ' .*' + os.release()), 'Checking OS version');
+}
+

--- a/test/test-os-version.js
+++ b/test/test-os-version.js
@@ -17,11 +17,17 @@ const os_name = os_map[os.platform()];
 const report_str = nodereport.getReport();
 const version_str = report_str.match(/OS version: .*(?:\r*\n)/);
 if (common.isWindows()) {
-  tap.match(version_str, new RegExp('OS version: ' + os_name), 'Checking OS version');
+  tap.match(version_str,
+            new RegExp('OS version: ' + os_name), 'Checking OS version');
 } else if (common.isAIX() && !os.release().includes('.')) {
-  // For Node.js prior to os.release() fix for AIX:  https://github.com/nodejs/node/pull/10245
-  tap.match(version_str, new RegExp('OS version: ' + os_name + ' \\d+.' + os.release()), 'Checking OS version');
-} else if (!common.isWindows()) {
-  tap.match(version_str, new RegExp('OS version: ' + os_name + ' .*' + os.release()), 'Checking OS version');
+  // For Node.js prior to os.release() fix for AIX:
+  // https://github.com/nodejs/node/pull/10245
+  tap.match(version_str,
+            new RegExp('OS version: ' + os_name + ' \\d+.' + os.release()),
+            'Checking OS version');
+} else {
+  tap.match(version_str,
+            new RegExp('OS version: ' + os_name + ' .*' + os.release()),
+            'Checking OS version');
 }
 


### PR DESCRIPTION
uname on AIX reports, e.g. 6.1 as version == 6, release == 1. 
The code was previously printing this as:
```
OS version: AIX 1 6
```
Fix so that on AIX this is now:
```
OS version: AIX 6.1
```

https://github.com/nodejs/node/pull/10245 fixed a similar area in Node.js.
