### PR TITLE
test: fix test-api-getreport.js

### DIFF
--- a/test/test-api-getreport.js
+++ b/test/test-api-getreport.js
@@ -1,11 +1,11 @@
 'use strict';
 
-// Testcase for returning NodeReport as a string via API call
+// Testcase for returning report as a string via API call
 
 const common = require('./common.js');
 const tap = require('tap');
 const nodereport = require('../');
 var report_str = nodereport.getReport();
 common.validateContent(report_str, tap, {pid: process.pid,
-  commandline: [process.argv0, 'test/test-api-getreport.js'].join(' ')
+  commandline: [process.argv[0], 'test/test-api-getreport.js'].join(' ')
 });

--- a/test/test-api-getreport.js
+++ b/test/test-api-getreport.js
@@ -2,10 +2,25 @@
 
 // Testcase for returning report as a string via API call
 
-const common = require('./common.js');
-const tap = require('tap');
-const nodereport = require('../');
-var report_str = nodereport.getReport();
-common.validateContent(report_str, tap, {pid: process.pid,
-  commandline: [process.argv[0], 'test/test-api-getreport.js'].join(' ')
-});
+if (process.argv[2] === 'child') {
+  const nodereport = require('../');
+  console.log(nodereport.getReport());
+} else {
+  const common = require('./common.js');
+  const spawnSync = require('child_process').spawnSync;
+  const tap = require('tap');
+  
+  const args = [__filename, 'child'];
+  const child = spawnSync(process.execPath, args);
+  tap.plan(3);
+  tap.strictSame(child.stderr.toString(), '',
+                 'Checking no messages on stderr');
+  const reportFiles = common.findReports(child.pid);
+  tap.same(reportFiles, [], 'Checking no report files were written');
+  tap.test('Validating report content', (t) => {
+    common.validateContent(child.stdout, t, { pid: child.pid,
+      commandline: process.execPath + ' ' + args.join(' ')
+    }); 
+  });
+}
+


### PR DESCRIPTION
I missed this when reviewing #48 :disappointed:. The new test fails on Node.js v4: https://ci.nodejs.org/view/post-mortem/job/nodereport-continuous-integration/51/
e.g. https://ci.nodejs.org/view/post-mortem/job/nodereport-continuous-integration/51/MACHINE=ubuntu1404-64/console
```
verbose: e46e12b6b495d53f5a38ce3315099be4755dfef4 npm-test:| # Subtest: test/test-api-getreport.js
verbose: e46e12b6b495d53f5a38ce3315099be4755dfef4 npm-test:| 1..17               
verbose: e46e12b6b495d53f5a38ce3315099be4755dfef4 npm-test:| ok 1 - Checking report contains Node Report section
verbose: e46e12b6b495d53f5a38ce3315099be4755dfef4 npm-test:| ok 2 - Checking report contains JavaScript Stack Trace section     
verbose:                                                   | ok 3 - Checking report contains JavaScript Heap section            
verbose:                                                   | ok 4 - Checking report contains System Information section         
verbose:                                                   | ok 5 - Node Report header section contains expected process ID     
verbose:                                                   | ok 6 - Node Report header section contains expected Node.js version
verbose: e46e12b6b495d53f5a38ce3315099be4755dfef4 npm-test:| not ok 7 - Checking report contains expected command line
verbose: e46e12b6b495d53f5a38ce3315099be4755dfef4 npm-test:| ---                                                                                                              
verbose:                                                   | found: >-                                                                                                        
verbose:                                                   | Event: JavaScript API, location: "GetReport"                                                                     
verbose:                                                   |                                                                                                                  
verbose:                                                   | Dump event time:  2017/02/10 12:43:29                                                                            
verbose:                                                   |                                                                                                                  
verbose:                                                   | Module load time: 2017/02/10 12:43:29                                                                            
verbose:                                                   |                                                                                                                  
verbose:                                                   | Process ID: 3038                                                                                                 
verbose:                                                   |                                                                                                                  
verbose:                                                   | Command line:                                                                                                    
verbose:                                                   | /home/iojs/build/workspace/nodereport-continuous-integration/MACHINE/ubuntu1404-64/node-v4.7.3-linux-x64/bin/node
verbose:                                                   | test/test-api-getreport.js                                                                                       
verbose:                                                   |                                                                                                                  
verbose:                                                   |                                                                                                                  
verbose:                                                   | Node.js version: v4.7.3                                                                                          
verbose:                                                   |                                                                                                                  
verbose:                                                   | (ares: 1.10.1-DEV, http_parser: 2.7.0, icu: 56.1, modules: 46, openssl:                                          
verbose:                                                   | 1.0.2k,                                                                                                          
verbose:                                                   | uv: 1.9.1, v8: 4.5.103.43, zlib: 1.2.8)                                                                          
verbose:                                                   |                                                                                                                  
verbose:                                                   | node-report version: 2.0.0 (built against Node.js v4.7.3)                                                        
verbose:                                                   |                                                                                                                  
verbose:                                                   |                                                                                                                  
verbose:                                                   | OS version: Linux 3.13.0-71-generic #114-Ubuntu SMP Tue Dec 1 02:34:22 UTC                                       
verbose:                                                   | 2015                                                                                                             
verbose:                                                   |                                                                                                                  
verbose:                                                   | (glibc: 2.19)                                                                                                    
verbose: e46e12b6b495d53f5a38ce3315099be4755dfef4 npm-test:| Machine: test-ibm-ubuntu1404-x64-1 x86_64              
verbose:                                                   | pattern: '/Command line:  test\/test-api-getreport.js/'
verbose:                                                   | at:                                                    
verbose:                                                   | line: 77                                               
verbose:                                                   | column: 9                                              
verbose:                                                   | file: test/common.js                                   
verbose:                                                   | function: validateContent                              
verbose:                                                   | stack: |                                               
verbose:                                                   | Object.validateContent (test/common.js:77:9)           
verbose:                                                   | Object.<anonymous> (test/test-api-getreport.js:9:8)    
verbose:                                                   | source: |                                              
verbose:                                                   | t.match(nodeReportSection,                             
verbose:                                                   | ...                                                    
verbose: e46e12b6b495d53f5a38ce3315099be4755dfef4 npm-test:| ok 8 - Node Report header section contains expected http_parser version
verbose:                                                   | ok 9 - Node Report header section contains expected v8 version         
verbose:                                                   | ok 10 - Node Report header section contains expected uv version        
verbose:                                                   | ok 11 - Node Report header section contains expected zlib version      
verbose:                                                   | ok 12 - Node Report header section contains expected ares version      
verbose: e46e12b6b495d53f5a38ce3315099be4755dfef4 npm-test:| ok 13 - Node Report header section contains expected icu version        
verbose:                                                   | ok 14 - Node Report header section contains expected modules version    
verbose:                                                   | ok 15 - Node Report header section contains expected openssl version    
verbose:                                                   | ok 16 - Node Report header section contains expected Node Report version
verbose:                                                   | ok 17 - System Information section contains node-report library.        
verbose:                                                   | # failed 1 of 17 tests                                                  
verbose:                                                   | # time=82.498ms                                                         
verbose:                                                   | not ok 4 - test/test-api-getreport.js # time=463.781ms                  
verbose: e46e12b6b495d53f5a38ce3315099be4755dfef4 npm-test:| ---                                                                                                              
verbose:                                                   | arguments:                                                                                                       
verbose:                                                   | - test/test-api-getreport.js                                                                                     
verbose:                                                   | results:                                                                                                         
verbose:                                                   | count: 17                                                                                                        
verbose:                                                   | fail: 1                                                                                                          
verbose:                                                   | pass: 16                                                                                                         
verbose:                                                   | plan:                                                                                                            
verbose:                                                   | start: 1                                                                                                         
verbose:                                                   | end: 17                                                                                                          
verbose:                                                   | ok: false                                                                                                        
verbose:                                                   | command: >-                                                                                                      
verbose:                                                   | /home/iojs/build/workspace/nodereport-continuous-integration/MACHINE/ubuntu1404-64/node-v4.7.3-linux-x64/bin/node
verbose:                                                   | file: test/test-api-getreport.js                                                                                 
verbose:                                                   | exitCode: 1                                                                                                      
verbose:                                                   | timeout: 30000                                                                                                   
verbose:                                                   | ...                                                                     
```

The test is using [`process.argv0`](https://nodejs.org/dist/latest-v6.x/docs/api/process.html#process_process_argv0), which doesn't exist in Node.js v4.

I also fixed up the comment in the testcase in light of the rename.