### PR TITLE
windows: fix reporting of machine name

### DIFF
--- a/src/node_report.cc
+++ b/src/node_report.cc
@@ -674,16 +674,23 @@ static void PrintVersionInformation(std::ostream& out) {
       }
       out <<  "\nOS version: " << os_name << "\n";
 
+      // Convert and print the machine name and comment fields (these are LPWSTR types)
+      size_t count;
+      char name_buf[256];
+      wcstombs_s(&count, name_buf, sizeof(name_buf), os_info->sv101_name, _TRUNCATE);
       if (os_info->sv101_comment != NULL) {
-        out << "\nMachine: " << os_info->sv101_name << " "
-            <<  os_info->sv101_comment << "\n";
+        char comment_buf[256];
+        wcstombs_s(&count, comment_buf, sizeof(comment_buf), os_info->sv101_comment, _TRUNCATE);
+        out << "\nMachine: " << name_buf << " " << comment_buf << "\n";
       } else {
-        out << "\nMachine: " << os_info->sv101_name << "\n";
+        out << "\nMachine: " << name_buf << "\n";
       }
+
       if (os_info != NULL) {
         NetApiBufferFree(os_info);
       }
     } else {
+      // NetServerGetInfo() call failed, fallback to use GetComputerName() instead
       TCHAR machine_name[256];
       DWORD machine_name_size = 256;
       out << "\nOS version: Windows\n";

--- a/test/common.js
+++ b/test/common.js
@@ -44,7 +44,7 @@ exports.validateContent = function validateContent(data, t, options) {
   const expectedVersions = options ?
                            options.expectedVersions || nodeComponents :
                            nodeComponents;
-  var plan = REPORT_SECTIONS.length + nodeComponents.length + 3;
+  var plan = REPORT_SECTIONS.length + nodeComponents.length + 4;
   if (options.commandline) plan++;
   t.plan(plan);
   // Check all sections are present
@@ -96,6 +96,12 @@ exports.validateContent = function validateContent(data, t, options) {
   t.match(nodeReportSection,
           new RegExp('node-report version: ' + nodereportMetadata.version),
           'Node Report header section contains expected Node Report version');
+  const os = require('os');
+  t.match(nodeReportSection,
+          new RegExp('Machine: ' + os.hostname()),
+          'Checking machine name in report header section contains os.hostname()');
+
+  // Check report System Information section
   const sysInfoSection = getSection(reportContents, 'System Information');
   // Find a line which ends with "/api.node" or "\api.node" (Unix or
   // Windows paths) to see if the library for node report was loaded.

--- a/test/common.js
+++ b/test/common.js
@@ -97,10 +97,20 @@ exports.validateContent = function validateContent(data, t, options) {
           new RegExp('node-report version: ' + nodereportMetadata.version),
           'Node Report header section contains expected Node Report version');
   const os = require('os');
-  t.match(nodeReportSection,
-          new RegExp('Machine: ' + os.hostname()),
-          'Checking machine name in report header section contains os.hostname()');
-
+  if (this.isWindows()) {
+    t.match(nodeReportSection,
+            new RegExp('Machine: ' + os.hostname(), 'i'), // ignore case on Windows
+            'Checking machine name in report header section contains os.hostname()');
+  } else if (this.AIX()) {
+    t.match(nodeReportSection,
+            new RegExp('Machine: ' + os.hostname().split('.')[0]), // truncate on AIX
+            'Checking machine name in report header section contains os.hostname()');
+  } else {
+    t.match(nodeReportSection,
+            new RegExp('Machine: ' + os.hostname()),
+            'Checking machine name in report header section contains os.hostname()');
+  }
+  
   // Check report System Information section
   const sysInfoSection = getSection(reportContents, 'System Information');
   // Find a line which ends with "/api.node" or "\api.node" (Unix or

--- a/test/common.js
+++ b/test/common.js
@@ -101,7 +101,7 @@ exports.validateContent = function validateContent(data, t, options) {
     t.match(nodeReportSection,
             new RegExp('Machine: ' + os.hostname(), 'i'), // ignore case on Windows
             'Checking machine name in report header section contains os.hostname()');
-  } else if (this.AIX()) {
+  } else if (this.isAIX()) {
     t.match(nodeReportSection,
             new RegExp('Machine: ' + os.hostname().split('.')[0]), // truncate on AIX
             'Checking machine name in report header section contains os.hostname()');


### PR DESCRIPTION
The machine name and comment in the Windows SERVER_INFO_101 structure are wide strings (LPWSTR types) which are not handled correctly by the std::ostream operator. Fix is to convert them first using wcstombs_s().

Fixes https://github.com/nodejs/node-report/issues/59

We also considered changing ostream to wostream throughout, but the changes were quite wide-spread, and ended up with a problem in module.cc NAN_METHOD(GetReport) where Nan::New() does not support the wostream type.