### PR TITLE
Fix CI test failures

### DIFF
--- a/src/node_report.cc
+++ b/src/node_report.cc
@@ -31,14 +31,18 @@
 #include <inttypes.h>
 #include <cxxabi.h>
 #include <dlfcn.h>
-#ifdef __linux__
+#if defined(__linux__) || defined(__sun)
 #include <link.h>
+#endif
+#ifdef __sun
+#include <procfs.h>
+#endif
+#ifdef _AIX
+#include <sys/ldr.h>
+#include <sys/procfs.h>
 #endif
 #ifndef _AIX
 #include <execinfo.h>
-#else
-#include <sys/ldr.h>
-#include <sys/procfs.h>
 #endif
 #include <sys/utsname.h>
 #endif
@@ -334,7 +338,7 @@ void SetCommandLine() {
     commandline_string += separator + argv[i];
     separator = " ";
   }
-#elif _AIX
+#elif defined(_AIX) || defined(__sun)
   // Read the command line from /proc/self/cmdline
   char procbuf[64];
   snprintf(procbuf, sizeof(procbuf), "/proc/%d/psinfo", getpid());
@@ -348,8 +352,12 @@ void SetCommandLine() {
   if (bytesread == sizeof(psinfo_t)) {
     commandline_string = "";
     std::string separator = "";
+#ifdef _AIX
     char **argv = *((char ***) info.pr_argv);
-    for (uint32_t i = 0; i < info.pr_argc; i++) {
+#else
+    char **argv = ((char **) info.pr_argv);
+#endif
+    for (auto i = 0; i < info.pr_argc && argv[i] != nullptr; i++) {
       commandline_string += separator + argv[i];
       separator = " ";
     }
@@ -1087,14 +1095,18 @@ const static struct {
   {"core file size (blocks)       ", RLIMIT_CORE},
   {"data seg size (kbytes)        ", RLIMIT_DATA},
   {"file size (blocks)            ", RLIMIT_FSIZE},
-#ifndef _AIX
+#if !(defined(_AIX) || defined(__sun))
   {"max locked memory (bytes)     ", RLIMIT_MEMLOCK},
 #endif
+#ifndef __sun
   {"max memory size (kbytes)      ", RLIMIT_RSS},
+#endif
   {"open files                    ", RLIMIT_NOFILE},
   {"stack size (bytes)            ", RLIMIT_STACK},
   {"cpu time (seconds)            ", RLIMIT_CPU},
+#ifndef __sun
   {"max user processes            ", RLIMIT_NPROC},
+#endif
   {"virtual memory (kbytes)       ", RLIMIT_AS}
 };
 
@@ -1108,7 +1120,7 @@ const static struct {
       if (limit.rlim_cur == RLIM_INFINITY) {
         out << "       unlimited";
       } else {
-#ifdef _AIX
+#if defined(_AIX) || defined(__sun)
         snprintf(buf, sizeof(buf), "%16ld", limit.rlim_cur);
         out << buf;
 #else
@@ -1195,6 +1207,14 @@ static void PrintLoadedLibraries(std::ostream& out, Isolate* isolate) {
     } while (cur_info->ldinfo_next != 0);
   }
   free(buffer);
+#elif __sun
+  Link_map *p;
+
+  if (dlinfo(RTLD_SELF, RTLD_DI_LINKMAP, &p) != -1) {
+    for (Link_map *l = p; l != NULL; l = l->l_next) {
+      out << "  " << l->l_name << "\n";
+    }
+  }
 
 #elif _WIN32
   // Windows implementation - get a handle to the process.

--- a/src/node_report.cc
+++ b/src/node_report.cc
@@ -703,7 +703,7 @@ static void PrintVersionInformation(std::ostream& out) {
 #else
   // Print operating system and machine information (Unix/OSX)
   struct utsname os_info;
-  if (uname(&os_info) == 0) {
+  if (uname(&os_info) >= 0) {
 #if defined(_AIX)
     out << "\nOS version: " << os_info.sysname << " " << os_info.version << "."
         << os_info.release << "\n";

--- a/src/node_report.h
+++ b/src/node_report.h
@@ -5,9 +5,6 @@
 #ifndef _WIN32
 #include <unistd.h>
 #include <sys/types.h>
-#if !defined(__APPLE__) && !defined(_AIX)
-#include <features.h>
-#endif
 #endif
 
 namespace nodereport {

--- a/test/common.js
+++ b/test/common.js
@@ -27,6 +27,10 @@ exports.isPPC = () => {
   return process.arch.startsWith('ppc');
 };
 
+exports.isSunOS = () => {
+  return process.platform === 'sunos';
+};
+
 exports.isWindows = () => {
   return process.platform === 'win32';
 };

--- a/test/test-fatal-error.js
+++ b/test/test-fatal-error.js
@@ -31,7 +31,7 @@ if (process.argv[2] === 'child') {
     const options = {pid: child.pid};
     // Node.js currently overwrites the command line on AIX
     // https://github.com/nodejs/node/issues/10607
-    if (!common.isAIX()) {
+    if (!(common.isAIX() || common.isSunOS())) {
       options.commandline = child.spawnargs.join(' ');
     }
     common.validate(tap, report, options);

--- a/test/test-os-version.js
+++ b/test/test-os-version.js
@@ -25,6 +25,8 @@ if (common.isWindows()) {
   tap.match(version_str,
             new RegExp('OS version: ' + os_name + ' \\d+.' + os.release()),
             'Checking OS version');
+} else if (common.isSunOS()) {
+  //skip, uname call returns file not found on SunOS
 } else {
   tap.match(version_str,
             new RegExp('OS version: ' + os_name + ' .*' + os.release()),

--- a/test/test-os-version.js
+++ b/test/test-os-version.js
@@ -12,6 +12,7 @@ const os_map = {
   'darwin': 'Darwin',
   'linux': 'Linux',
   'win32': 'Windows',
+  'sunos': 'SunOS',
 };
 const os_name = os_map[os.platform()];
 const report_str = nodereport.getReport();

--- a/test/test-os-version.js
+++ b/test/test-os-version.js
@@ -25,8 +25,6 @@ if (common.isWindows()) {
   tap.match(version_str,
             new RegExp('OS version: ' + os_name + ' \\d+.' + os.release()),
             'Checking OS version');
-} else if (common.isSunOS()) {
-  //skip, uname call returns file not found on SunOS
 } else {
   tap.match(version_str,
             new RegExp('OS version: ' + os_name + ' .*' + os.release()),


### PR DESCRIPTION
This PR fixes the compilation errors on SmartOS so that citgm goes green and should resolve issue #50.

Mostly this fixes #ifdefs so we take the correct paths. The code for listing the loaded libraries is the only new code.

I had to make one test change to not check the OS version as calling uname() returns an error on SmartOS. (I formatted the errorno value and it seemed to be "No such file or directory", google suggested that the uname info might come from /etc/release so that might be missing. It's quite hard to tell without access to the machine though.)

Aside from that it seems to be fully functional. If there is extended information that SmartOS provides that other platforms don't (different ulimit values for example) those can be added under other PR's.

There's a CI run with the full set of platforms here:
https://ci.nodejs.org/view/post-mortem/job/nodereport-continuous-integration/83/