### PR TITLE
Fix return code from uncaught exception handler

### DIFF
--- a/src/module.cc
+++ b/src/module.cc
@@ -171,8 +171,9 @@ bool OnUncaughtException(v8::Isolate* isolate) {
       (commandline_string.find("abort_on_uncaught_exception") != std::string::npos)) {
     return true;  // abort required
   }
-  // On V8 versions earlier than 5.4 we need to print the exception backtrace
-  // to stderr, as V8 does not do so (unless we trigger an abort, as above).
+  // On versions earlier than 5.4, V8 does not provide the default behaviour
+  // for uncaught exception on return from this callback. Default behaviour is
+  // to print a stack trace and exit with rc=1, so we need to mimic that here.
   int v8_major, v8_minor;
   if (sscanf(v8::V8::GetVersion(), "%d.%d", &v8_major, &v8_minor) == 2) {
     if (v8_major < 5 || (v8_major == 5 && v8_minor < 4)) {
@@ -184,6 +185,8 @@ bool OnUncaughtException(v8::Isolate* isolate) {
       // On other platforms use the Message API
       Message::PrintCurrentStackTrace(isolate, stderr);
 #endif
+      // exit direct from this callback with rc=1, to mimic V8 behaviour
+      exit(1);
     }
   }
   return false;

--- a/test/test-exception.js
+++ b/test/test-exception.js
@@ -24,13 +24,7 @@ if (process.argv[2] === 'child') {
   });
   child.on('exit', (code) => {
     tap.plan(4);
-    // Verify exit code. Note that behaviour changed in V8 v5.4
-    const v8_version = (process.versions.v8).match(/\d+/g);
-    if (v8_version[0] < 5 || (v8_version[0] == 5 && v8_version[1] < 4)) {
-      tap.equal(code, 0, 'Check for expected process exit code');
-    } else {
-      tap.equal(code, 1, 'Check for expected process exit code');
-    }
+    tap.equal(code, 1, 'Check for expected process exit code');
     tap.match(stderr, /myException/,
               'Check for expected stack trace frame in stderr');
     const reports = common.findReports(child.pid);


### PR DESCRIPTION
On node 4 or 6, the uncaught exception handler produces a report then prints a stack trace OK, but node continues to run when the handler function returns. The expected behavior on uncaught exception is to exit with rc=1. This PR fixes the handler to exit with return code = 1, also fixes the corresponding testcase.

Fixes https://github.com/nodejs/node-report/issues/6

CI: https://ci.nodejs.org/view/post-mortem/job/nodereport-continuous-integration/118/