### PR TITLE
Improve usability of node-report demos

### DIFF
--- a/demo/api_call.js
+++ b/demo/api_call.js
@@ -1,24 +1,26 @@
-// Example - generation of report via API call
+// Example - generation of report via node-report API call
 var nodereport = require('node-report');
 var http = require("http");
 
-var count = 0;
-
 function my_listener(request, response) {
-  switch(count++) {
-  case 0:
-    response.writeHead(200,{"Content-Type": "text/plain"});
-    response.write("\nRunning node-report API demo... refresh page to trigger report");
+  switch (request.url) {
+  case '/trigger':
+    nodereport.triggerReport();
+    // drop through to refresh page
+  case '/':
+    response.writeHead(200, "OK",{'Content-Type': 'text/html'});
+    response.write('<html><head><title>node-report example</title></head><body style="font-family:arial;">');
+    response.write('<h2>node-report example: report triggered by JavaScript API call</h2>');
+    response.write('<p>Click on button below to trigger a report. The application will continue.');
+    response.write('<form enctype="application/x-www-form-urlencoded" action="/trigger" method="post">');
+    response.write('<button>Trigger report</button></form>');
+    response.write('<p>Click on button below to terminate the application.');
+    response.write('<form enctype="application/x-www-form-urlencoded" action="/end" method="post">');
+    response.write('<button>End application</button></form>');
+    response.write('</form></body></html');
     response.end();
     break;
-  case 1:
-    response.writeHead(200,{"Content-Type": "text/plain"});
-    // Call the node-report module to trigger a report
-    var filename = nodereport.triggerReport();
-    response.write("\n" + filename + " written - refresh page to close");
-    response.end();
-    break;
-  default:
+  case '/end':
     process.exit(0);
   }
 }
@@ -30,6 +32,6 @@ console.log('api_call.js: Node running');
 console.log('api_call.js: Go to http://<machine>:8080/ or http://localhost:8080/');
 
 setTimeout(function(){
-  console.log('api_call.js: test timeout expired, exiting.');
+  console.log('api_call.js: application timeout expired, exiting.');
   process.exit(0);
 }, 60000);

--- a/demo/exception.js
+++ b/demo/exception.js
@@ -1,24 +1,23 @@
 // Example - generation of report on uncaught exception
-require('node-report').setEvents("exception");
+require('node-report');
 var http = require("http");
 
-var count = 0;
-
 function my_listener(request, response) {
-  switch(count++) {
-  case 0:
-    response.writeHead(200,{"Content-Type": "text/plain"});
-    response.write("\nRunning node-report exception demo... refresh page to cause exception (application will terminate)");
+  switch (request.url) {
+  case '/':
+    response.writeHead(200, "OK",{'Content-Type': 'text/html'});
+    response.write('<html><head><title>node-report example</title></head><body style="font-family:arial;">');
+    response.write('<h2>node-report example: report triggered on uncaught exception</h2>');
+    response.write('<p>Click on button below to throw an exception. The exception is not caught by the application.');
+    response.write('<p>The node-report module will produce a report then terminate the application.');
+    response.write('<form enctype="application/x-www-form-urlencoded" action="/exception" method="post">');
+    response.write('<button>Throw exception</button></form>');
+    response.write('</form></body></html');
     response.end();
     break;
-  default:
-    throw new UserException('*** exception.js: exception thrown from my_listener()');
+  case '/exception':
+    throw new Error('*** exception.js: uncaught exception thrown from function my_listener()');
   }
-}
-
-function UserException(message) {
-  this.message = message;
-  this.name = "UserException";
 }
 
 var http_server = http.createServer(my_listener);
@@ -28,6 +27,6 @@ console.log('exception.js: Node running');
 console.log('exception.js: Go to http://<machine>:8080/ or http://localhost:8080/');
 
 setTimeout(function() {
-  console.log('exception.js: test timeout expired, exiting.');
+  console.log('exception.js: application timeout expired, exiting.');
   process.exit(0);
 }, 60000);

--- a/demo/fatalerror.js
+++ b/demo/fatalerror.js
@@ -1,28 +1,30 @@
-// Example - generation of report on fatal error (Javascript heap OOM)
-require('node-report').setEvents("fatalerror");
+// Example - generation of report on fatal error (JavaScript heap OOM)
+require('node-report');
 var http = require('http');
 
-var count = 0;
-
 function my_listener(request, response) {
-  switch(count++) {
-  case 0:
-    response.writeHead(200,{"Content-Type": "text/plain"});
-    response.write("\nRunning node-report fatal error demo... refresh page to trigger excessive memory usage (application will terminate)");
+  switch (request.url) {
+  case '/':
+    response.writeHead(200, "OK",{'Content-Type': 'text/html'});
+    response.write('<html><head><title>node-report example</title></head><body style="font-family:arial;">');
+    response.write('<h2>node-report example: report triggered on fatal error (heap OOM)</h2>');
+    response.write('<p>Click on button below to initiate excessive memory usage.');
+    response.write('<p>The application will fail when the heap is full, and the node-report module will produce a report.');
+    response.write('<form enctype="application/x-www-form-urlencoded" action="/memory" method="post">');
+    response.write('<button>Use memory</button></form>');
+    response.write('</form></body></html');
     response.end();
     break;
-  case 1:
-    console.log('heap_oom.js: allocating excessive Javascript heap memory....');
+  case '/memory':
+    console.log('fatalerror.js: allocating excessive JavaScript heap memory....please wait');
     var list = [];
-    while (true) {
-      list.push(new MyRecord());
-    }
+    while (true) list.push(new my_record());
     response.end();
     break;
   }
 }
 
-function MyRecord() {
+function my_record() {
   this.name = 'foo';
   this.id = 128;
   this.account = 98454324;
@@ -36,6 +38,6 @@ console.log('fatalerror.js: Note: heap default is 1.4Gb, use --max-old-space-siz
 console.log('fatalerror.js: Go to http://<machine>:8080/ or http://localhost:8080/');
 
 setTimeout(function(){
-  console.log('fatalerror.js: timeout expired, exiting.');
+  console.log('fatalerror.js: application timeout expired, exiting.');
   process.exit(0);
 }, 60000);

--- a/demo/loop.js
+++ b/demo/loop.js
@@ -1,19 +1,12 @@
 // Example - generation of report via signal for a looping application
-require('node-report').setEvents("signal");
+// Note: node-report signal trigger is not supported on Windows
+require('node-report');
 var http = require("http");
 
-var count = 0;
-
 function my_listener(request, response) {
-  switch(count++) {
-  case 0:
-    response.writeHead(200,{"Content-Type": "text/plain"});
-    response.write("\nRunning node-report looping application demo. Node process ID = " + process.pid);
-    response.write("\n\nRefresh page to enter loop, then use 'kill -USR2 " + process.pid + "' to trigger report");
-    response.end();
-    break;
-  case 1:
-    console.log("loop.js: going to loop now, use 'kill -USR2 " + process.pid + "' to trigger report");
+  switch (request.url) {
+  case '/loop':
+    console.log("loop.js: going to busy loop now, use 'kill -USR2 " + process.pid + "' to trigger report");
     var list = [];
     for (var i=0; i<10000000000; i++) {
       for (var j=0; i<1000; i++) {
@@ -27,11 +20,23 @@ function my_listener(request, response) {
         list.pop();
       }
     }
-    response.writeHead(200,{"Content-Type": "text/plain"});
-    response.write("\nnode-report demo.... finished looping");
+    // drop through to refresh page
+  case '/':
+    response.writeHead(200, "OK",{'Content-Type': 'text/html'});
+    response.write('<html><head><title>node-report example</title></head><body style="font-family:arial;">');
+    response.write('<h2>node-report example: report triggered using USR2 signal</h2>');
+    response.write('<p>Click on button below to enter JavaScript busy loop, then');
+    response.write(' use "kill -USR2 ' + process.pid + '" in a terminal window to trigger report');
+    response.write('<form enctype="application/x-www-form-urlencoded" action="/loop" method="post">');
+    response.write('<button>Enter busy loop</button></form>');
+    response.write('<p>When busy loop completes, click on button below to terminate the application.');
+    response.write('<form enctype="application/x-www-form-urlencoded" action="/end" method="post">');
+    response.write('<button>End application</button></form>');
+    response.write('</form></body></html');
     response.end();
     break;
-  default:
+  case '/end':
+    process.exit(0);
   }
 }
 


### PR DESCRIPTION
- Provide buttons to trigger the failure events (rather than using browser refresh)
- html output instead of plain text
- Improve demo code to switch on request.url instead of a count
- Improve various messages produced by the demos
- Remove `setEvents() `calls (not required now as hooks are on by default)