### PR TITLE
Increase tap timeout for node-report CI testing

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "Richard Chamberlain <richard_chamberlain@uk.ibm.com> (https://github.com/rnchamberlain)"
   ],
   "scripts": {
-    "test": "tap test/test*.js"
+    "test": "tap --timeout=300 test/test*.js"
   },
   "bugs": {
     "url": "https://github.com/nodejs/node-report/issues"


### PR DESCRIPTION
The default tap test timeout is 30 secs, which is not sufficient for the OOM test (test-fatal-error.js) on the CI AIX machines. The test has been seen to pass in 2-3 mins. Fix is to increase the timeout to 5 mins, which allows for some margin.

Fixes https://github.com/nodejs/node-report/issues/69

CI: https://ci.nodejs.org/job/nodereport-continuous-integration/123/