### PR TITLE
report: add bitness of the process

### DIFF
--- a/src/node_report.cc
+++ b/src/node_report.cc
@@ -635,7 +635,8 @@ static void PrintVersionInformation(std::ostream& out) {
 #if defined(__GLIBC__)
   out << ", glibc " << __GLIBC__ << "." << __GLIBC_MINOR__;
 #endif
-  out << ")" << std::endl;
+  // Print Process word size
+  out << ", " << sizeof(void *) * 8 << " bit" << ")" << std::endl;
 
   // Print operating system and machine information (Windows)
 #ifdef _WIN32


### PR DESCRIPTION
Add the bitness information of the process in the node-report
helps in diagnosing OOM scenarios in the context of available
memory. In 32 bit node process, the OOM situation warrants a
different resolution path than in 64 bit case.

Read and understood the contributing guidelines and agree to the terms. Please let me know if you need more information. Thanks.