### PR TITLE
Fix the use of %p to format handle pointers on non-Windows platforms.

### DIFF
--- a/src/node_report.cc
+++ b/src/node_report.cc
@@ -517,7 +517,11 @@ static void walkHandle(uv_handle_t* h, void* arg) {
   }
 
   snprintf(buf, sizeof(buf),
+#ifdef _WIN32
               "[%c%c]   %-10s0x%p\n",
+#else
+              "[%c%c]   %-10s%p\n",
+#endif
               uv_has_ref(h)?'R':'-',
               uv_is_active(h)?'A':'-',
               type.c_str(), (void*)h);


### PR DESCRIPTION
The libuv handle pointers are currently being formatted with an extra 0x on non-Windows platforms as the %p format adds the 0x prefix on those platforms, for example:
`[-A]   async     0x0x101526178`

This patch just adds the same #ifdef we use else where in node-report when we use the %p format.