### PR TITLE
windows: fix compile time error on mktime

### DIFF
--- a/src/node_report.cc
+++ b/src/node_report.cc
@@ -302,7 +302,7 @@ void SetLoadTime() {
   gettimeofday(&time_val, nullptr);
   localtime_r(&time_val.tv_sec, &loadtime_tm_struct);
 #endif
-load_time = mktime(&loadtime_tm_struct);
+  time(&load_time);
 }
 
 /*******************************************************************************


### PR DESCRIPTION
Obtain the start time via as a time_t via time() so we can do a
simple uptime calculation later on via difftime().

This should resolve issue #83.