### PR TITLE
node_report.cc: Fix CreateMessage call

### DIFF
--- a/src/node_report.cc
+++ b/src/node_report.cc
@@ -805,7 +805,11 @@ static void PrintJavaScriptErrorStack(std::ostream& out, Isolate* isolate, Maybe
 
   out << "\n================================================================================";
   out << "\n==== JavaScript Exception Details ==============================================\n\n";
+#if NODE_MAJOR_VERSION > 5
   Local<Message> message = v8::Exception::CreateMessage(isolate, error.ToLocalChecked());
+#else
+  Local<Message> message = v8::Exception::CreateMessage(error.ToLocalChecked());
+#endif
   Nan::Utf8String message_str(message->Get());
 
   out << *message_str << "\n\n";


### PR DESCRIPTION
This change fixes a compile failure caused by using a version of v8::Exception::CreateMessage that does not exist on Node.js releases earlier than 6.
On 6 and later the older version of CreateMessage is deprecated so the new version is used.

I have done CI runs against Node 4, 5 and 6 with this change:
https://ci.nodejs.org/view/post-mortem/job/nodereport-continuous-integration/162/
https://ci.nodejs.org/view/post-mortem/job/nodereport-continuous-integration/163/
https://ci.nodejs.org/view/post-mortem/job/nodereport-continuous-integration/165/

(Run 164 was a run of node-report/master against Node 4 to confirm I could reproduce the problem.)

This should resolve issue #87 

