### PR TITLE
Improve OOM testcase speed

### DIFF
--- a/test/test-fatal-error.js
+++ b/test/test-fatal-error.js
@@ -13,7 +13,7 @@ if (process.argv[2] === 'child') {
 
   function MyRecord() {
     this.name = 'foo';
-    this.buffer = Buffer.alloc(100000, 1);
+    this.buffer = Buffer.alloc(1000, 1);
   }
 
 } else {

--- a/test/test-fatal-error.js
+++ b/test/test-fatal-error.js
@@ -13,7 +13,7 @@ if (process.argv[2] === 'child') {
 
   function MyRecord() {
     this.name = 'foo';
-    this.buffer = Buffer.alloc(1000, 1);
+    this.buffer = Buffer.alloc(10000, 1);
   }
 
 } else {
@@ -22,7 +22,7 @@ if (process.argv[2] === 'child') {
   const spawn = require('child_process').spawn;
   const tap = require('tap');
 
-  const args = ['--max-old-space-size=20', __filename, 'child'];
+  const args = ['--max-old-space-size=10', __filename, 'child'];
   const child = spawn(process.execPath, args);
   child.on('exit', (code) => {
     tap.plan(3);

--- a/test/test-fatal-error.js
+++ b/test/test-fatal-error.js
@@ -1,10 +1,11 @@
 'use strict';
 
-// Testcase to produce report on fatal error (javascript heap OOM)
+// Testcase to produce report on fatal error (JavaScript heap OOM)
 if (process.argv[2] === 'child') {
   require('../');
 
   const list = [];
+  // Loop adding objects to the list until heap is full
   while (true) {
     const record = new MyRecord();
     list.push(record);
@@ -12,10 +13,11 @@ if (process.argv[2] === 'child') {
 
   function MyRecord() {
     this.name = 'foo';
-    this.id = 128;
-    this.account = 98454324;
+    this.buffer = Buffer.alloc(100000, 1);
   }
+
 } else {
+  // Testcase parent process implementation
   const common = require('./common.js');
   const spawn = require('child_process').spawn;
   const tap = require('tap');


### PR DESCRIPTION
Improve the speed of the OOM testcase (test-fatal-error.js) so that it fills the heap and fails more quickly. On slower CI machines the test was sometimes timing out. Fix is to use a large buffer to incrementally consume memory rather than just small strings and numbers. This gives an approx 10x speed up.

CI run: https://ci.nodejs.org/view/post-mortem/job/nodereport-continuous-integration/186/