### PR TITLE
Support for node-report on native sigsegv/sigill/sigfpe

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ It includes JavaScript and native stack traces, heap statistics,
 platform information and resource usage etc. Reports can be triggered on
 unhandled exceptions, fatal errors, signals and calls to JavaScript APIs.
 
-Supports Node.js v4, v6 and v8 on AIX, Linux, MacOS, SmartOS and Windows.
+Supports Node.js version 4, 6 and 8 on AIX, Linux, MacOS, SmartOS and Windows.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -5,11 +5,10 @@ Delivers a human-readable diagnostic summary, written to file.
 The report is intended for development, test and production
 use, to capture and preserve information for problem determination.
 It includes JavaScript and native stack traces, heap statistics,
-platform information and resource usage etc. With the report enabled,
-reports can be triggered on unhandled exceptions, fatal errors, signals
-and calls to a JavaScript API.
+platform information and resource usage etc. Reports can be triggered on
+unhandled exceptions, fatal errors, signals and calls to JavaScript APIs.
 
-Supports Node.js v4, v6 and v7 on AIX, Linux, MacOS, SmartOS and Windows.
+Supports Node.js v4, v6 and v8 on AIX, Linux, MacOS, SmartOS and Windows.
 
 ## Usage
 
@@ -17,9 +16,9 @@ Supports Node.js v4, v6 and v7 on AIX, Linux, MacOS, SmartOS and Windows.
 npm install node-report
 node -r node-report app.js
 ```
-A report will be triggered automatically on unhandled exceptions and fatal
-error events (for example out of memory errors), and can also be triggered
-by sending a USR2 signal to a Node.js process (not supported on Windows).
+A report will be triggered automatically on unhandled exceptions, fatal errors
+(for example out of memory errors) and crashes in native code. A report can also be
+triggered by sending a USR2 signal to a Node.js process (not supported on Windows).
 
 A report can also be triggered via an API call from a JavaScript
 application.
@@ -37,7 +36,7 @@ var report_str = nodereport.getReport();
 console.log(report_str);
 ```
 The API can be used without adding the automatic exception and fatal error
-hooks and the signal handler, as follows:
+hooks and the signal handlers, as follows:
 
 ```js
 var nodereport = require('node-report/api');
@@ -95,7 +94,7 @@ Additional configuration is available using the following APIs:
 
 ```js
 var nodereport = require('node-report/api');
-nodereport.setEvents("exception+fatalerror+signal+apicall");
+nodereport.setEvents("exception+fatalerror+signal+apicall+crash");
 nodereport.setSignal("SIGUSR2|SIGQUIT");
 nodereport.setFileName("stdout|stderr|<filename>");
 nodereport.setDirectory("<full path>");
@@ -105,7 +104,7 @@ nodereport.setVerbose("yes|no");
 Configuration on module initialization is also available via environment variables:
 
 ```bash
-export NODEREPORT_EVENTS=exception+fatalerror+signal+apicall
+export NODEREPORT_EVENTS=exception+fatalerror+signal+apicall+crash
 export NODEREPORT_SIGNAL=SIGUSR2|SIGQUIT
 export NODEREPORT_FILENAME=stdout|stderr|<filename>
 export NODEREPORT_DIRECTORY=<full path>

--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@
 const api = require('./api');
 
 // NODEREPORT_EVENTS env var overrides the defaults
-const options = process.env.NODEREPORT_EVENTS || 'exception+fatalerror+signal+apicall';
+const options = process.env.NODEREPORT_EVENTS || 'exception+fatalerror+signal+apicall+crash';
 api.setEvents(options);
 
 exports.triggerReport = api.triggerReport;

--- a/src/module.cc
+++ b/src/module.cc
@@ -16,7 +16,8 @@ static int StartWatchdogThread(void* (*thread_main)(void* unused));
 static void RegisterSignalHandler(int signo, void (*handler)(int),
                                   struct sigaction* saved_sa);
 static void RestoreSignalHandler(int signo, struct sigaction* saved_sa);
-static void SignalDump(int signo);
+static void SignalHandler(int signo);
+static void CrashHandler(int signo);
 static void SetupSignalHandler();
 #endif
 
@@ -31,7 +32,10 @@ static int report_signal = 0;  // atomic for signal handling in progress
 static uv_sem_t report_semaphore;  // semaphore for hand-off to watchdog
 static uv_async_t nodereport_trigger_async;  // async handle for event loop
 static uv_mutex_t node_isolate_mutex;  // mutex for watchdog thread
-static struct sigaction saved_sa;  // saved signal action
+static struct sigaction saved_user_sa;  // saved user signal action
+static struct sigaction saved_sigsegv_sa;  // saved crash signal action
+static struct sigaction saved_sigill_sa;  // saved crash signal action
+static struct sigaction saved_sigfpe_sa;  // saved crash signal action
 #endif
 
 // State variables for v8 hooks and signal initialisation
@@ -128,7 +132,20 @@ NAN_METHOD(SetEvents) {
   }
   // If report no longer required on external user signal, reset the OS signal handler
   if (!(nodereport_events & NR_SIGNAL) && (previous_events & NR_SIGNAL)) {
-    RestoreSignalHandler(nodereport_signal, &saved_sa);
+    RestoreSignalHandler(nodereport_signal, &saved_user_sa);
+  }
+
+  // If report newly requested on native crash, set up signal handlers
+  if ((nodereport_events & NR_CRASH) && !(previous_events & NR_CRASH)) {
+    RegisterSignalHandler(SIGSEGV, CrashHandler, &saved_sigsegv_sa);
+    RegisterSignalHandler(SIGILL, CrashHandler, &saved_sigill_sa);
+    RegisterSignalHandler(SIGFPE, CrashHandler, &saved_sigfpe_sa);
+  }
+  // If report no longer required on native crash, reset the signal handlers
+  if (!(nodereport_events & NR_CRASH) && (previous_events & NR_CRASH)) {
+    RestoreSignalHandler(SIGSEGV, &saved_sigsegv_sa);
+    RestoreSignalHandler(SIGILL, &saved_sigill_sa);
+    RestoreSignalHandler(SIGFPE, &saved_sigfpe_sa);
   }
 #endif
 }
@@ -140,8 +157,8 @@ NAN_METHOD(SetSignal) {
 
   // If signal event active and selected signal has changed, switch the OS signal handler
   if ((nodereport_events & NR_SIGNAL) && (nodereport_signal != previous_signal)) {
-    RestoreSignalHandler(previous_signal, &saved_sa);
-    RegisterSignalHandler(nodereport_signal, SignalDump, &saved_sa);
+    RestoreSignalHandler(previous_signal, &saved_user_sa);
+    RegisterSignalHandler(nodereport_signal, SignalHandler, &saved_user_sa);
   }
 #endif
 }
@@ -268,8 +285,9 @@ static void SignalDumpAsyncCallback(uv_async_t* handle) {
 
 /*******************************************************************************
  * Utility functions for signal handling support (platforms except Windows)
- *  - RegisterSignalHandler() - register a raw OS signal handler
- *  - SignalDump() - implementation of raw OS signal handler
+ *  - RegisterSignalHandler() - register an OS signal handler
+ *  - SignalHandler() - implementation of OS signal handler for external signals
+ *  - CrashHandler() - implementation of OS signal handler for crash signals
  *  - StartWatchdogThread() - create a watchdog thread
  *  - ReportSignalThreadMain() - implementation of watchdog thread
  *  - SetupSignalHandler() - initialisation of signal handlers and threads
@@ -289,12 +307,28 @@ static void RestoreSignalHandler(int signo, struct sigaction* saved_sa) {
   sigaction(signo, saved_sa, nullptr);
 }
 
-// Raw signal handler for triggering a report - runs on an arbitrary thread
-static void SignalDump(int signo) {
+// Native signal handler for triggering a report on user signal - runs on an arbitrary thread
+static void SignalHandler(int signo) {
   // Check atomic for report already pending, storing the signal number
   if (__sync_val_compare_and_swap(&report_signal, 0, signo) == 0) {
     uv_sem_post(&report_semaphore);  // Hand-off to watchdog thread
   }
+}
+
+// Native signal handler for triggering a report on a crash, runs on crashing thread
+static void CrashHandler(int signo) {
+  // Remove node-report crash handlers in case we get a secondary crash
+  RestoreSignalHandler(signo, &saved_sigsegv_sa);
+  RestoreSignalHandler(signo, &saved_sigill_sa);
+  RestoreSignalHandler(signo, &saved_sigfpe_sa);
+  // Also remove the node-report user signal handler, if set
+  if (nodereport_events & NR_SIGNAL) {
+    RestoreSignalHandler(nodereport_signal, &saved_user_sa);
+  }
+  TriggerNodeReport(Isolate::GetCurrent(), kCrashSignal, node::signo_string(signo),
+                    __func__, nullptr, MaybeLocal<Value>());
+  // Propagate the signal
+  raise(signo);
 }
 
 // Utility function to start a watchdog thread - used for processing signals
@@ -361,7 +395,7 @@ static void SetupSignalHandler() {
       Nan::ThrowError("node-report: initialization failed, uv_async_init() returned error\n");
     }
     uv_unref(reinterpret_cast<uv_handle_t*>(&nodereport_trigger_async));
-    RegisterSignalHandler(nodereport_signal, SignalDump, &saved_sa);
+    RegisterSignalHandler(nodereport_signal, SignalHandler, &saved_user_sa);
     signal_thread_initialised = true;
   }
 }
@@ -419,6 +453,12 @@ void Initialize(v8::Local<v8::Object> exports) {
   // If report requested on external user signal set up watchdog thread and callbacks
   if (nodereport_events & NR_SIGNAL) {
     SetupSignalHandler();
+  }
+  // If report requested on crash signal set up crash handler
+  if (nodereport_events & NR_CRASH) {
+    RegisterSignalHandler(SIGSEGV, CrashHandler, &saved_sigsegv_sa);
+    RegisterSignalHandler(SIGILL, CrashHandler, &saved_sigill_sa);
+    RegisterSignalHandler(SIGFPE, CrashHandler, &saved_sigfpe_sa);
   }
 #endif
 

--- a/src/node_report.cc
+++ b/src/node_report.cc
@@ -1000,6 +1000,9 @@ static void PrintJavaScriptStack(std::ostream& out, Isolate* isolate, DumpEvent 
     // Print the stack using StackTrace::StackTrace() and GetStackSample() APIs
     PrintStackFromStackTrace(out, isolate, event);
     break;
+  case kKillSignal:
+    out << "Crash signal received from external process, no stack trace available\n";
+    break;
   }  // end switch(event)
 #endif
 }

--- a/src/node_report.cc
+++ b/src/node_report.cc
@@ -140,6 +140,9 @@ unsigned int ProcessNodeReportEvents(const char* args) {
     } else if (!strncmp(cursor, "apicall", sizeof("apicall") - 1)) {
       event_flags |= NR_APICALL;
       cursor += sizeof("apicall") - 1;
+    } else if (!strncmp(cursor, "crash", sizeof("crash") - 1)) {
+      event_flags |= NR_CRASH;
+      cursor += sizeof("crash") - 1;
     } else {
       std::cerr << "Unrecognised argument for node-report events option: " << cursor << "\n";
       return 0;
@@ -460,7 +463,7 @@ void TriggerNodeReport(Isolate* isolate, DumpEvent event, const char* message, c
       }
       return;
     } else {
-      std::cerr << "\nWriting Node.js report to file: " << filename << "\n";
+      std::cerr << "Writing Node.js report to file: " << filename << "\n";
     }
   }
 
@@ -993,6 +996,7 @@ static void PrintJavaScriptStack(std::ostream& out, Isolate* isolate, DumpEvent 
     break;
   case kSignal_JS:
   case kSignal_UV:
+  case kCrashSignal:
     // Print the stack using StackTrace::StackTrace() and GetStackSample() APIs
     PrintStackFromStackTrace(out, isolate, event);
     break;

--- a/src/node_report.h
+++ b/src/node_report.h
@@ -26,12 +26,13 @@ using v8::MaybeLocal;
 #define NR_FATALERROR 0x02
 #define NR_SIGNAL     0x04
 #define NR_APICALL    0x08
+#define NR_CRASH      0x10
 
 // Maximum file and path name lengths
 #define NR_MAXNAME 64
 #define NR_MAXPATH 1024
 
-enum DumpEvent {kException, kFatalError, kSignal_JS, kSignal_UV, kJavaScript};
+enum DumpEvent {kException, kFatalError, kSignal_JS, kSignal_UV, kJavaScript, kCrashSignal};
 
 void TriggerNodeReport(Isolate* isolate, DumpEvent event, const char* message, const char* location, char* name, v8::MaybeLocal<v8::Value> error);
 void GetNodeReport(Isolate* isolate, DumpEvent event, const char* message, const char* location, v8::MaybeLocal<v8::Value> error, std::ostream& out);

--- a/src/node_report.h
+++ b/src/node_report.h
@@ -32,7 +32,7 @@ using v8::MaybeLocal;
 #define NR_MAXNAME 64
 #define NR_MAXPATH 1024
 
-enum DumpEvent {kException, kFatalError, kSignal_JS, kSignal_UV, kJavaScript, kCrashSignal};
+enum DumpEvent {kException, kFatalError, kSignal_JS, kSignal_UV, kJavaScript, kCrashSignal, kKillSignal};
 
 void TriggerNodeReport(Isolate* isolate, DumpEvent event, const char* message, const char* location, char* name, v8::MaybeLocal<v8::Value> error);
 void GetNodeReport(Isolate* isolate, DumpEvent event, const char* message, const char* location, v8::MaybeLocal<v8::Value> error, std::ostream& out);

--- a/test/test-sigfpe.js
+++ b/test/test-sigfpe.js
@@ -1,0 +1,50 @@
+'use strict';
+
+// Testcase to produce report on native crash (sigfpe)
+
+// This testcase uses process.kill() to raise the sigfpe signal rather than
+// producing a real arithmetic exception (which would require native code). The
+// code exercised in node-report is the same.
+
+if (process.argv[2] === 'child') {
+  // Child process implementation
+  require('../');
+  process.kill(process.pid, 'SIGFPE');
+
+} else {
+  // Parent process implementation
+  const common = require('./common.js');
+  const spawn = require('child_process').spawn;
+  const tap = require('tap');
+  const fs = require('fs');
+
+  if (common.isWindows()) {
+    tap.fail('Native crash support not available on Windows', { skip: true });
+    return;
+  }
+
+  const child = spawn(process.execPath, [__filename, 'child']);
+  
+  // Capture stderr output from the child process
+  var stderr = '';
+  child.stderr.on('data', (chunk) => {stderr += chunk;});
+
+  // Validation on child exit
+  child.on('exit', (code) => {
+    tap.plan(4);
+    tap.notEqual(code, 1, 'Check for expected non-zero exit code');
+    const reports = common.findReports(child.pid);
+    tap.equal(reports.length, 1, 'Found reports ' + reports);
+    const report = reports[0];
+
+    // Testcase-specific report validation
+    fs.readFile(report, (err, data) => { 
+      const headerSection = common.getSection(data, 'Node Report');
+      tap.match(headerSection, /SIGFPE/,
+                'Checking that header section contains crash signal name');
+    });
+    // Common report validation
+    const options = {pid: child.pid, commandline: child.spawnargs.join(' ')};
+    common.validate(tap, report, options);
+  });
+}

--- a/test/test-sigill.js
+++ b/test/test-sigill.js
@@ -1,0 +1,50 @@
+'use strict';
+
+// Testcase to produce report on native crash (sigill)
+
+// This testcase uses process.kill() to raise the sigill signal rather than
+// executing a real illegal instruction (which would require native code). The
+// code exercised in node-report is the same.
+
+if (process.argv[2] === 'child') {
+  // Child process implementation
+  require('../');
+  process.kill(process.pid, 'SIGILL');
+
+} else {
+  // Parent process implementation
+  const common = require('./common.js');
+  const spawn = require('child_process').spawn;
+  const tap = require('tap');
+  const fs = require('fs');
+
+  if (common.isWindows()) {
+    tap.fail('Native crash support not available on Windows', { skip: true });
+    return;
+  }
+
+  const child = spawn(process.execPath, [__filename, 'child']);
+  
+  // Capture stderr output from the child process
+  var stderr = '';
+  child.stderr.on('data', (chunk) => {stderr += chunk;});
+
+  // Validation on child exit
+  child.on('exit', (code) => {
+    tap.plan(4);
+    tap.notEqual(code, 1, 'Check for expected non-zero exit code');
+    const reports = common.findReports(child.pid);
+    tap.equal(reports.length, 1, 'Found reports ' + reports);
+    const report = reports[0];
+
+    // Testcase-specific report validation
+    fs.readFile(report, (err, data) => { 
+      const headerSection = common.getSection(data, 'Node Report');
+      tap.match(headerSection, /SIGILL/,
+                'Checking that header section contains crash signal name');
+    });
+    // Common report validation
+    const options = {pid: child.pid, commandline: child.spawnargs.join(' ')};
+    common.validate(tap, report, options);
+  });
+}

--- a/test/test-sigsegv.js
+++ b/test/test-sigsegv.js
@@ -1,0 +1,50 @@
+'use strict';
+
+// Testcase to produce report on native crash (sigsegv)
+
+// This testcase uses process.kill() to raise the sigsegv signal rather than
+// producing a real segmentation fault (which would require native code). The
+// code exercised in node-report is the same.
+
+if (process.argv[2] === 'child') {
+  // Child process implementation
+  require('../');
+  process.kill(process.pid, 'SIGSEGV');
+
+} else {
+  // Parent process implementation
+  const common = require('./common.js');
+  const spawn = require('child_process').spawn;
+  const tap = require('tap');
+  const fs = require('fs');
+
+  if (common.isWindows()) {
+    tap.fail('Native crash support not available on Windows', { skip: true });
+    return;
+  }
+
+  const child = spawn(process.execPath, [__filename, 'child']);
+  
+  // Capture stderr output from the child process
+  var stderr = '';
+  child.stderr.on('data', (chunk) => {stderr += chunk;});
+
+  // Validation when child process exits
+  child.on('exit', (code) => {
+    tap.plan(4);
+    tap.notEqual(code, 1, 'Check for expected non-zero exit code');
+    const reports = common.findReports(child.pid);
+    tap.equal(reports.length, 1, 'Found reports ' + reports);
+    const report = reports[0];
+
+    // Testcase-specific report validation
+    fs.readFile(report, (err, data) => { 
+      const headerSection = common.getSection(data, 'Node Report');
+      tap.match(headerSection, /SIGSEGV/,
+                'Checking that header section contains crash signal name');
+    });
+    // Common report validation
+    const options = {pid: child.pid, commandline: child.spawnargs.join(' ')};
+    common.validate(tap, report, options);
+  });
+}


### PR DESCRIPTION
Adds support for triggering node-report on sigsegv, sigill and sigfpe signals. Currently, when a crash occurs in a native add-on, all you get is the "`Segmentation fault (core dumped)`" message. Purpose of this support is to provide more information on crashes, in particular native and JS stacktraces, version information and list of loaded modules.

The new hooks are on by default if node-report is required in the application or using` -r node-report` on the command line. On/off configuration is available using a new 'crash' keyword on the `nodereport.setEvents()` call or the `NODEREPORT_EVENTS` environment variable. The existing `require('node-report/api')` style also allows you to enable node-report without the signal hooks. On a crash the user will see:

```
Writing Node.js report to file: node-report.20170717.121031.4211.001.txt
Node.js report completed
Segmentation fault (core dumped)

```
Implementation adds native signal handlers for the crash signals, and triggers a node-report in those handlers, then re-raises the signal. Strictly speaking we should only use async-signal-safe functions within a signal handler, see http://man7.org/linux/man-pages/man7/signal-safety.7.html. If for example the crash occurs inside a printf() call, the behavior of a printf() call from within the signal handler is undefined. In practice crashes most often occur in application code, and producing a report from the signal handler is OK. The signal handlers are removed before the node-report is written, so any secondary crash will terminate the process immediately in the normal way.

Testcases are included, Node 8 CI run is here: https://ci.nodejs.org/view/post-mortem/job/nodereport-continuous-integration/196/