### PR TITLE
Update README to show support for Node.js 8

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ platform information and resource usage etc. With the report enabled,
 reports can be triggered on unhandled exceptions, fatal errors, signals
 and calls to a JavaScript API.
 
-Supports Node.js v4, v6 and v7 on AIX, Linux, MacOS, SmartOS and Windows.
+Supports Node.js versions 4, 6 and 8 on AIX, Linux, MacOS, SmartOS and Windows.
 
 ## Usage
 


### PR DESCRIPTION
Update README to remove Node.js 7 and add Node.js 8 to the version support statement. The CI tests run OK on Node.js 8.

Also changed the wording a bit to avoid possible v8/V8 confusion.