### PR TITLE
Replace node::signo_string with local implementation

### DIFF
--- a/src/module.cc
+++ b/src/module.cc
@@ -245,7 +245,7 @@ static void SignalDumpInterruptCallback(Isolate* isolate, void* data) {
         fprintf(stdout, "node-report: SignalDumpInterruptCallback triggering report\n");
       }
       TriggerNodeReport(isolate, kSignal_JS,
-                        node::signo_string(report_signal), __func__, nullptr, MaybeLocal<Value>());
+                        SignoString(report_signal), __func__, nullptr, MaybeLocal<Value>());
     }
     report_signal = 0;
   }
@@ -260,7 +260,7 @@ static void SignalDumpAsyncCallback(uv_async_t* handle) {
         fprintf(stdout, "node-report: SignalDumpAsyncCallback triggering NodeReport\n");
       }
       TriggerNodeReport(Isolate::GetCurrent(), kSignal_UV,
-                        node::signo_string(report_signal), __func__, nullptr, MaybeLocal<Value>());
+                        SignoString(report_signal), __func__, nullptr, MaybeLocal<Value>());
     }
     report_signal = 0;
   }
@@ -327,7 +327,7 @@ inline void* ReportSignalThreadMain(void* unused) {
   for (;;) {
     uv_sem_wait(&report_semaphore);
     if (nodereport_verbose) {
-      fprintf(stdout, "node-report: signal %s received\n", node::signo_string(report_signal));
+      fprintf(stdout, "node-report: signal %s received\n", SignoString(report_signal));
     }
     uv_mutex_lock(&node_isolate_mutex);
     if (auto isolate = node_isolate) {

--- a/src/node_report.h
+++ b/src/node_report.h
@@ -72,6 +72,7 @@ void reportEndpoints(uv_handle_t* h, std::ostringstream& out);
 void reportPath(uv_handle_t* h, std::ostringstream& out);
 void walkHandle(uv_handle_t* h, void* arg);
 void WriteInteger(std::ostream& out, size_t value);
+const char *SignoString(int signo);
 
 // Global variable declarations - definitions are in src/node-report.c
 extern char report_filename[NR_MAXNAME + 1];

--- a/src/utilities.cc
+++ b/src/utilities.cc
@@ -451,11 +451,7 @@ void walkHandle(uv_handle_t* h, void* arg) {
       // See http://docs.libuv.org/en/v1.x/signal.html
       type = "signal";
       data << "signum: " << handle->signal.signum
-      // node::signo_string() is not exported by Node.js on Windows.
-#ifndef _WIN32
-           << " (" << node::signo_string(handle->signal.signum) << ")"
-#endif
-           ;
+           << " (" << SignoString(handle->signal.signum) << ")";
       break;
     }
     case UV_FILE: type = "file"; break;
@@ -547,6 +543,134 @@ void WriteInteger(std::ostream& out, size_t value) {
     if (i > 0) {
       out << ",";
     }
+  }
+}
+
+/*******************************************************************************
+ * Utility function to convert a numeric signal number to a string.
+ *
+ * This code has been copied from node/src/node.cc function signo_string().
+ ******************************************************************************/
+const char *SignoString(int signo) {
+#define SIGNO_CASE(e)  case e: return #e;
+  switch (signo) {
+#ifdef SIGHUP
+  SIGNO_CASE(SIGHUP);
+#endif
+#ifdef SIGINT
+  SIGNO_CASE(SIGINT);
+#endif
+#ifdef SIGQUIT
+  SIGNO_CASE(SIGQUIT);
+#endif
+#ifdef SIGILL
+  SIGNO_CASE(SIGILL);
+#endif
+#ifdef SIGTRAP
+  SIGNO_CASE(SIGTRAP);
+#endif
+#ifdef SIGABRT
+  SIGNO_CASE(SIGABRT);
+#endif
+#ifdef SIGIOT
+# if SIGABRT != SIGIOT
+  SIGNO_CASE(SIGIOT);
+# endif
+#endif
+#ifdef SIGBUS
+  SIGNO_CASE(SIGBUS);
+#endif
+#ifdef SIGFPE
+  SIGNO_CASE(SIGFPE);
+#endif
+#ifdef SIGKILL
+  SIGNO_CASE(SIGKILL);
+#endif
+#ifdef SIGUSR1
+  SIGNO_CASE(SIGUSR1);
+#endif
+#ifdef SIGSEGV
+  SIGNO_CASE(SIGSEGV);
+#endif
+#ifdef SIGUSR2
+  SIGNO_CASE(SIGUSR2);
+#endif
+#ifdef SIGPIPE
+  SIGNO_CASE(SIGPIPE);
+#endif
+#ifdef SIGALRM
+  SIGNO_CASE(SIGALRM);
+#endif
+  SIGNO_CASE(SIGTERM);
+#ifdef SIGCHLD
+  SIGNO_CASE(SIGCHLD);
+#endif
+#ifdef SIGSTKFLT
+  SIGNO_CASE(SIGSTKFLT);
+#endif
+#ifdef SIGCONT
+  SIGNO_CASE(SIGCONT);
+#endif
+#ifdef SIGSTOP
+  SIGNO_CASE(SIGSTOP);
+#endif
+#ifdef SIGTSTP
+  SIGNO_CASE(SIGTSTP);
+#endif
+#ifdef SIGBREAK
+  SIGNO_CASE(SIGBREAK);
+#endif
+#ifdef SIGTTIN
+  SIGNO_CASE(SIGTTIN);
+#endif
+#ifdef SIGTTOU
+  SIGNO_CASE(SIGTTOU);
+#endif
+#ifdef SIGURG
+  SIGNO_CASE(SIGURG);
+#endif
+#ifdef SIGXCPU
+  SIGNO_CASE(SIGXCPU);
+#endif
+#ifdef SIGXFSZ
+  SIGNO_CASE(SIGXFSZ);
+#endif
+#ifdef SIGVTALRM
+  SIGNO_CASE(SIGVTALRM);
+#endif
+#ifdef SIGPROF
+  SIGNO_CASE(SIGPROF);
+#endif
+#ifdef SIGWINCH
+  SIGNO_CASE(SIGWINCH);
+#endif
+#ifdef SIGIO
+  SIGNO_CASE(SIGIO);
+#endif
+#ifdef SIGPOLL
+#if SIGPOLL != SIGIO
+  SIGNO_CASE(SIGPOLL);
+#endif
+#endif
+#ifdef SIGLOST
+#if SIGLOST != SIGABRT
+  SIGNO_CASE(SIGLOST);
+#endif
+#endif
+#ifdef SIGPWR
+#if SIGPWR != SIGLOST
+  SIGNO_CASE(SIGPWR);
+#endif
+#endif
+#ifdef SIGINFO
+#if !defined(SIGPWR) || SIGINFO != SIGPWR
+  SIGNO_CASE(SIGINFO);
+#endif
+#endif
+#ifdef SIGSYS
+  SIGNO_CASE(SIGSYS);
+#endif
+  default: return "unknown";
   }
 }
 


### PR DESCRIPTION
This PR copies the implementation of node::signo_string() into node-report, renaming the function to SignoString(). 

Fixes https://github.com/nodejs/node-report/issues/100

Clean CI run on Node 8: https://ci.nodejs.org/job/nodereport-continuous-integration/211/