### PR TITLE
Fix use of deprecated methods removed in V8 7.0

### DIFF
--- a/src/node_report.cc
+++ b/src/node_report.cc
@@ -509,7 +509,11 @@ static void PrintJavaScriptErrorStack(std::ostream& out, Isolate* isolate, Maybe
   }
   // Print the stack trace, samples are not available as the exception isn't from the current stack.
   for (int i = 0; i < stack->GetFrameCount(); i++) {
-    PrintStackFrame(out, isolate, stack->GetFrame(i), i, nullptr);
+    PrintStackFrame(out, isolate, stack->GetFrame(
+#if defined(V8_MAJOR_VERSION) && (V8_MAJOR_VERSION >= 7)
+                                                  isolate,
+#endif
+                                                  i), i, nullptr);
   }
 }
 
@@ -545,9 +549,17 @@ static void PrintStackFromStackTrace(std::ostream& out, Isolate* isolate, DumpEv
   // Print the stack trace, adding in the pc values from GetStackSample() if available
   for (int i = 0; i < stack->GetFrameCount(); i++) {
     if (static_cast<size_t>(i) < info.frames_count) {
-      PrintStackFrame(out, isolate, stack->GetFrame(i), i, samples[i]);
+      PrintStackFrame(out, isolate, stack->GetFrame(
+#if defined(V8_MAJOR_VERSION) && (V8_MAJOR_VERSION >= 7)
+                                                    isolate,
+#endif
+                                                    i), i, samples[i]);
     } else {
-      PrintStackFrame(out, isolate, stack->GetFrame(i), i, nullptr);
+      PrintStackFrame(out, isolate, stack->GetFrame(
+#if defined(V8_MAJOR_VERSION) && (V8_MAJOR_VERSION >= 7)
+                                                    isolate,
+#endif
+                                                    i), i, nullptr);
     }
   }
 }


### PR DESCRIPTION
`StackFrame::GetFrame(uint32_t index)` was deprecated in V8 6.9 and
removed in V8 7.0.

Refs: https://github.com/nodejs/node/pull/22531

This fixes the errors compiling against the current Node.js master 
(12.0.0-pre) that originate in this project. Resolving other compilation 
errors require `nan` to release a fix containing https://github.com/nodejs/nan/pull/831.

Refs: https://github.com/nodejs/node-report/issues/116