### PR TITLE
chore: update dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "node": ">=4.0.0"
   },
   "dependencies": {
-    "nan": "^2.3.5"
+    "nan": "^2.12.1"
   },
   "license": "MIT",
   "contributors": [
@@ -24,6 +24,6 @@
     "url": "https://github.com/nodejs/node-report/issues"
   },
   "devDependencies": {
-    "tap": "^8.0.0"
+    "tap": "~12.4.1"
   }
 }


### PR DESCRIPTION
Fixes `npm audit` warnings from outdated `tap` plugin.

```
12:21:51 added 303 packages from 230 contributors and audited 714 packages in 15.182s
12:21:51 found 35 vulnerabilities (15 low, 19 moderate, 1 high)
```