### PR TITLE
Fix use of deprecated methods removed in V8 7.0

### DIFF
--- a/src/module.cc
+++ b/src/module.cc
@@ -212,7 +212,11 @@ static void PrintStackFromStackTrace(Isolate* isolate, FILE* fp) {
                                                           StackTrace::kDetailed);
   // Print the JavaScript function name and source information for each frame
   for (int i = 0; i < stack->GetFrameCount(); i++) {
-    Local<StackFrame> frame = stack->GetFrame(i);
+    Local<StackFrame> frame = stack->GetFrame(
+#if defined(V8_MAJOR_VERSION) && (V8_MAJOR_VERSION >= 7)
+                                              isolate,
+#endif
+                                              i);
     Nan::Utf8String fn_name_s(frame->GetFunctionName());
     Nan::Utf8String script_name(frame->GetScriptName());
     const int line_number = frame->GetLineNumber();


### PR DESCRIPTION
StackFrame::GetFrame(uint32_t index) was deprecated in V8 6.9 and
removed in V8 7.0.

Missed a Windows only instance in 26f88d0.

Refs: https://github.com/nodejs/node-report/pull/119