### PR TITLE
Remove `setCoreDump`

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,7 +9,6 @@ api.setEvents(options);
 exports.triggerReport = api.triggerReport;
 exports.getReport = api.getReport;
 exports.setEvents = api.setEvents;
-exports.setCoreDump = api.setCoreDump;
 exports.setSignal = api.setSignal;
 exports.setFileName = api.setFileName;
 exports.setDirectory = api.setDirectory;


### PR DESCRIPTION
The native binding doesn't actually export a `setCoreDump` method so
we were exporting `undefined` instead of an actual function.