### PR TITLE
Fixes/port for node-report on z/OS:

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -14,7 +14,7 @@
           "dll_files": [ "dbghelp.dll", "Netapi32.dll", "PsApi.dll", "Ws2_32.dll" ],
         }],
         ["OS=='zos'", {
-          "cflags!": [ "-O2", "-O3" ], # till defect RTC 160544 is resolved
+          "cflags!": [ "-O2", "-O3" ],
           "cflags": [ "-qascii" ],
         }],
       ],

--- a/binding.gyp
+++ b/binding.gyp
@@ -13,6 +13,10 @@
           "libraries": [ "dbghelp.lib", "Netapi32.lib", "PsApi.lib", "Ws2_32.lib" ],
           "dll_files": [ "dbghelp.dll", "Netapi32.dll", "PsApi.dll", "Ws2_32.dll" ],
         }],
+        ["OS=='zos'", {
+          "cflags!": [ "-O2", "-O3" ], # till defect RTC 160544 is resolved
+          "cflags": [ "-qascii" ],
+        }],
       ],
       "defines": [
         'NODEREPORT_VERSION="<!(node -p \"require(\'./package.json\').version\")"'

--- a/src/node_report.cc
+++ b/src/node_report.cc
@@ -495,9 +495,6 @@ static void PrintJavaScriptStack(std::ostream& out, Isolate* isolate, DumpEvent 
       std::fflush(stack_fp);
       std::rewind(stack_fp);
       while (std::fgets(stack_buf, sizeof(stack_buf), stack_fp) != nullptr) {
-        #ifdef __MVS__
-          __e2a_s(stack_buf);
-        #endif
         out << stack_buf;
       }
       // Calling close on a file from tmpfile *should* delete it.

--- a/src/node_report.cc
+++ b/src/node_report.cc
@@ -34,7 +34,7 @@
 #endif
 // Include execinfo.h for the native backtrace API. The API is unavailable on AIX
 // and on some Linux distributions, e.g. Alpine Linux.
-#if !defined(_AIX) && !(defined(__linux__) && !defined(__GLIBC__))
+#if !defined(_AIX) && !(defined(__linux__) && !defined(__GLIBC__)) && !defined(__MVS__)
 #include <execinfo.h>
 #endif
 #include <sys/utsname.h>
@@ -46,6 +46,20 @@
 
 #ifndef _WIN32
 extern char** environ;
+#endif
+
+#ifdef __MVS__
+class __auto_ascii {
+public:
+  __auto_ascii();
+  ~__auto_ascii();
+};
+extern "C" int backtrace(void **buffer, int size);
+extern "C" char **backtrace_symbols(void *const *buffer, int size);
+extern "C" void *__dlcb_next(void *last);
+extern "C" int __dlcb_entry_name(char *buf, int size, void *dlcb);
+extern "C" void *__dlcb_entry_addr(void *dlcb);
+extern "C" int __find_file_in_path(char *out, int size, const char *envvar, const char *file);
 #endif
 
 namespace nodereport {
@@ -138,6 +152,9 @@ void TriggerNodeReport(Isolate* isolate, DumpEvent event, const char* message, c
   }
 
   // Open the report file stream for writing. Supports stdout/err, user-specified or (default) generated name
+#ifdef __MVS__
+  __auto_ascii _a;
+#endif
   std::ofstream outfile;
   std::ostream* outstream = &std::cout;
   if (!strncmp(filename, "stdout", sizeof("stdout") - 1)) {
@@ -420,12 +437,29 @@ static void PrintVersionInformation(std::ostream& out) {
     out << "\nOS version: " << os_info.sysname << " " << os_info.release << " "
         << os_info.version << "\n";
 #endif
+#if defined(__MVS__)
+    char *r;
+    __asm(" llgt %0,1208 \n"
+          " lg   %0,88(%0) \n"
+          " lg   %0,8(%0) \n"
+          " lg   %0,984(%0) \n"
+          : "=r"(r)::);
+    if (r != NULL) {
+      const char *prod = (int)r[80]==4 ? " (MVS LE)" : "";
+      out << "\nProduct " << (int)r[80] << prod << " Version " << (int)r[81] << " Release " << (int)r[82] << " Modification " << (int)r[83] << std::endl;
+    }
+    char hn[256];
+    memset(hn,0,sizeof(hn));
+    gethostname(hn,sizeof(hn));
+    out <<  "\nMachine: " << hn << " " << os_info.nodename << " " << os_info.machine << "\n";
+#else
     const char *(*libc_version)();
     *(void**)(&libc_version) = dlsym(RTLD_DEFAULT, "gnu_get_libc_version");
     if (libc_version != NULL) {
       out << "(glibc: " << (*libc_version)() << ")" << std::endl;
     }
     out <<  "\nMachine: " << os_info.nodename << " " << os_info.machine << "\n";
+#endif
   }
 #endif
 }
@@ -461,6 +495,9 @@ static void PrintJavaScriptStack(std::ostream& out, Isolate* isolate, DumpEvent 
       std::fflush(stack_fp);
       std::rewind(stack_fp);
       while (std::fgets(stack_buf, sizeof(stack_buf), stack_fp) != nullptr) {
+        #ifdef __MVS__
+          __e2a_s(stack_buf);
+        #endif
         out << stack_buf;
       }
       // Calling close on a file from tmpfile *should* delete it.
@@ -694,9 +731,20 @@ void PrintNativeStack(std::ostream& out) {
     return;
   }
 
+#ifdef __MVS__
+  char **res = backtrace_symbols(frames, size);
+  if (!res)
+    return;
+  int start_index = 0;
+#else
   // Print the native frames, omitting the top 3 frames as they are in node-report code
-  // backtrace_symbols_fd(frames, size, fileno(fp));
-  for (int i = 2; i < size; i++) {
+  int start_index = 2;
+#endif
+  for (int i = start_index; i < size; i++) {
+#ifdef __MVS__
+    // print traceback symbols and addresses
+    out << res[i] << std::endl;
+#else
     // print frame index and instruction address
     snprintf(buf, sizeof(buf), "%2d: [pc=%p] ", i-2, frames[i]);
     out << buf;
@@ -716,7 +764,11 @@ void PrintNativeStack(std::ostream& out) {
       }
     }
     out << std::endl;
+#endif
   }
+#ifdef __MVS__
+  free(res);
+#endif
 }
 #endif
 
@@ -786,7 +838,7 @@ static void PrintResourceUsage(std::ostream& out) {
   struct rusage stats;
   out << "\nProcess total resource usage:";
   if (getrusage(RUSAGE_SELF, &stats) == 0) {
-#if defined(__APPLE__) || defined(_AIX)
+#if defined(__APPLE__) || defined(_AIX) || defined(__MVS__)
     snprintf( buf, sizeof(buf), "%ld.%06d", stats.ru_utime.tv_sec, stats.ru_utime.tv_usec);
     out << "\n  User mode CPU: " << buf << " secs";
     snprintf( buf, sizeof(buf), "%ld.%06d", stats.ru_stime.tv_sec, stats.ru_stime.tv_usec);
@@ -801,11 +853,13 @@ static void PrintResourceUsage(std::ostream& out) {
     cpu_percentage = (cpu_abs / uptime) * 100.0;
     out << "\n  Average CPU Consumption : "<< cpu_percentage << "%";
     out << "\n  Maximum resident set size: ";
+#if !defined(__MVS__)
     WriteInteger(out, stats.ru_maxrss * 1024);
     out << " bytes\n  Page faults: " << stats.ru_majflt << " (I/O required) "
         << stats.ru_minflt << " (no I/O required)";
     out << "\n  Filesystem activity: " << stats.ru_inblock << " reads "
         <<  stats.ru_oublock << " writes";
+#endif
   }
 #ifdef RUSAGE_THREAD
   out << "\n\nEvent loop thread resource usage:";
@@ -893,16 +947,16 @@ const static struct {
   {"core file size (blocks)       ", RLIMIT_CORE},
   {"data seg size (kbytes)        ", RLIMIT_DATA},
   {"file size (blocks)            ", RLIMIT_FSIZE},
-#if !(defined(_AIX) || defined(__sun))
+#if !(defined(_AIX) || defined(__sun) || defined(__MVS__))
   {"max locked memory (bytes)     ", RLIMIT_MEMLOCK},
 #endif
-#ifndef __sun
+#if !(defined(__sun) || defined(__MVS__))
   {"max memory size (kbytes)      ", RLIMIT_RSS},
 #endif
   {"open files                    ", RLIMIT_NOFILE},
   {"stack size (bytes)            ", RLIMIT_STACK},
   {"cpu time (seconds)            ", RLIMIT_CPU},
-#ifndef __sun
+#if !(defined(__sun) || defined(__MVS__))
   {"max user processes            ", RLIMIT_NPROC},
 #endif
   {"virtual memory (kbytes)       ", RLIMIT_AS}
@@ -1055,6 +1109,25 @@ static void PrintLoadedLibraries(std::ostream& out, Isolate* isolate) {
   }
   // Release the handle to the process.
   CloseHandle(process_handle);
+
+#elif __MVS__
+  void *dlcb = 0;
+  const int max_path = 1024;
+  char buffer[max_path];
+  char filename[max_path];
+  char *libpath = __getenv("LIBPATH");
+  while (dlcb = __dlcb_next(dlcb), dlcb) {
+    int len = __dlcb_entry_name(buffer, sizeof(buffer), dlcb);
+    void *addr = __dlcb_entry_addr(dlcb);
+    if (0 == addr)
+      continue;
+    if (buffer[0] != '/' && libpath && __find_file_in_path(filename, sizeof(filename), libpath, buffer) > 0) {
+      snprintf(buffer + len, sizeof(buffer) - len, " => %s (0x%p)", filename, addr);
+    } else
+      snprintf(buffer + len, sizeof(buffer) - len, " (0x%p)", addr);
+    out << "  " << buffer << std::endl;
+  }
+  out << std::flush;
 #endif
 }
 

--- a/src/node_report.cc
+++ b/src/node_report.cc
@@ -735,16 +735,15 @@ void PrintNativeStack(std::ostream& out) {
   char **res = backtrace_symbols(frames, size);
   if (!res)
     return;
-  int start_index = 0;
-#else
-  // Print the native frames, omitting the top 3 frames as they are in node-report code
-  int start_index = 2;
-#endif
-  for (int i = start_index; i < size; i++) {
-#ifdef __MVS__
+  for (int i = 0; i < size; i++) {
     // print traceback symbols and addresses
     out << res[i] << std::endl;
+  }
+  free(res);
 #else
+  // Print the native frames, omitting the top 3 frames as they are in node-report code
+  // backtrace_symbols_fd(frames, size, fileno(fp));
+  for (int i = 2; i < size; i++) {
     // print frame index and instruction address
     snprintf(buf, sizeof(buf), "%2d: [pc=%p] ", i-2, frames[i]);
     out << buf;
@@ -764,10 +763,7 @@ void PrintNativeStack(std::ostream& out) {
       }
     }
     out << std::endl;
-#endif
   }
-#ifdef __MVS__
-  free(res);
 #endif
 }
 #endif

--- a/test/common.js
+++ b/test/common.js
@@ -10,6 +10,7 @@ const osMap = {
   'linux': 'Linux',
   'sunos': 'SunOS',
   'win32': 'Windows',
+  'os390': 'OS/390',
 };
 
 const REPORT_SECTIONS = [


### PR DESCRIPTION
- Fix compiler errors
- Change ebcdic output to ascii
- Native Stack Trace and JavaScript Stack Trace
- Command line
- Loaded libraries
- Hostname
- Filename output in fs_event
- Listening socket tcp uv handle
- OS Version check