### PR TITLE
errors caught from n-api addons shouldn't trigger UncaughtException reports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@
 # Build directories
 /build/
 /node_modules/
+/test/*/build/
 
 # Package files
 NodeReport*.txt

--- a/test/nan_throw/binding.gyp
+++ b/test/nan_throw/binding.gyp
@@ -1,0 +1,17 @@
+{
+  "targets": [
+    {
+      "target_name": "test_nan_throw",
+      "include_dirs": [ '<!(node -e "require(\'nan\')")' ],
+      "conditions": [
+        ["OS=='linux'", {
+          "defines": [ "_GNU_SOURCE" ],
+          "cflags": [ "-g", "-O2", "-std=c++11", ],
+        }],
+      ],
+      "sources": [
+        "test_nan_throw.cc"
+      ]
+    }
+  ]
+}

--- a/test/nan_throw/package-lock.json
+++ b/test/nan_throw/package-lock.json
@@ -1,0 +1,5 @@
+{
+  "name": "test_nan_throw",
+  "version": "1.0.0",
+  "lockfileVersion": 1
+}

--- a/test/nan_throw/package.json
+++ b/test/nan_throw/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "test_nan_throw",
+  "version": "1.0.0",
+  "description": "Throw an error.",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "install": "node-gyp rebuild"
+  },
+  "author": "",
+  "license": "ISC",
+  "repository": "https://github.com/nodejs/node-report",
+  "gypfile": true
+}

--- a/test/nan_throw/test_nan_throw.cc
+++ b/test/nan_throw/test_nan_throw.cc
@@ -1,0 +1,13 @@
+#include <assert.h>
+
+#include <nan.h>
+
+NAN_METHOD(ThrowError) {
+  Nan::ThrowError("an error occurred"); 
+}
+
+NAN_MODULE_INIT(Init) {
+  Nan::SetMethod(target, "throwError", ThrowError);
+}
+
+NODE_MODULE(NODE_GYP_MODULE_NAME, Init)

--- a/test/napi_throw/binding.gyp
+++ b/test/napi_throw/binding.gyp
@@ -1,0 +1,10 @@
+{
+  "targets": [
+    {
+      "target_name": "test_napi_throw",
+      "sources": [
+        "test_napi_throw.c"
+      ]
+    }
+  ]
+}

--- a/test/napi_throw/package-lock.json
+++ b/test/napi_throw/package-lock.json
@@ -1,0 +1,5 @@
+{
+  "name": "test_napi_throw",
+  "version": "1.0.0",
+  "lockfileVersion": 1
+}

--- a/test/napi_throw/package.json
+++ b/test/napi_throw/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "test_napi_throw",
+  "version": "1.0.0",
+  "description": "Throw an error.",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "install": "node-gyp rebuild"
+  },
+  "author": "",
+  "license": "ISC",
+  "repository": "https://github.com/nodejs/node-report",
+  "gypfile": true
+}

--- a/test/napi_throw/test_napi_throw.c
+++ b/test/napi_throw/test_napi_throw.c
@@ -8,20 +8,23 @@ napi_value ThrowError(napi_env env, napi_callback_info info) {
 }
 
 static napi_value Init(napi_env env, napi_value exports) {
+  napi_status status;
   napi_value result;
-  assert(napi_create_object(env, &result) == napi_ok);
   napi_value exported_function;
-  assert(napi_create_function(env,
-                              "throwError",
-                              NAPI_AUTO_LENGTH,
-                              ThrowError,
-                              NULL,
-                              &exported_function) == napi_ok);
-  
-  assert(napi_set_named_property(env,
-                                 result,
-                                 "throwError",
-                                 exported_function) == napi_ok);
+  status = napi_create_object(env, &result);
+  assert(status == napi_ok);
+  status = napi_create_function(env,
+                                "throwError",
+                                NAPI_AUTO_LENGTH,
+                                ThrowError,
+                                NULL,
+                                &exported_function);
+  assert(status == napi_ok);
+  status = napi_set_named_property(env,
+                                   result,
+                                   "throwError",
+                                   exported_function);
+  assert(status == napi_ok);
   return result;
 }
 

--- a/test/napi_throw/test_napi_throw.c
+++ b/test/napi_throw/test_napi_throw.c
@@ -1,0 +1,28 @@
+#include <assert.h>
+
+#include <node_api.h>
+
+napi_value ThrowError(napi_env env, napi_callback_info info) {
+  napi_throw_error(env, NULL, "an error occurred"); 
+  return NULL;
+}
+
+static napi_value Init(napi_env env, napi_value exports) {
+  napi_value result;
+  assert(napi_create_object(env, &result) == napi_ok);
+  napi_value exported_function;
+  assert(napi_create_function(env,
+                              "throwError",
+                              NAPI_AUTO_LENGTH,
+                              ThrowError,
+                              NULL,
+                              &exported_function) == napi_ok);
+  
+  assert(napi_set_named_property(env,
+                                 result,
+                                 "throwError",
+                                 exported_function) == napi_ok);
+  return result;
+}
+
+NAPI_MODULE(NODE_GYP_MODULE_NAME, Init)

--- a/test/test-nan-throw.js
+++ b/test/test-nan-throw.js
@@ -1,0 +1,22 @@
+'use strict';
+
+const tap = require('tap');
+
+// Build addon that throws an error
+const cp = require('child_process');
+const path = require('path');
+const build = cp.spawnSync('npm', [ 'install', '.',],
+                           { cwd: path.join(__dirname, 'nan_throw'),
+                           encoding: 'utf8' });
+tap.equal(build.stderr, '', 'No errors building addon');
+tap.equal(build.signal, null, 'Failed to build addon');
+tap.equal(build.status, 0, 'Failed to build addon');
+
+// Test catching the error does not trigger an UncaughtException report
+const common = require('./common.js');
+const report = require('../');
+const obj = require('./nan_throw/build/Release/test_nan_throw.node');
+tap.throws(obj.throwError);
+
+const reports = common.findReports(process.pid);
+tap.same(reports, [], 'No reports should be generated');

--- a/test/test-napi-throw.js
+++ b/test/test-napi-throw.js
@@ -1,0 +1,22 @@
+'use strict';
+
+const tap = require('tap');
+
+// Build addon that throws an error
+const cp = require('child_process');
+const path = require('path');
+const build = cp.spawnSync('npm', [ 'install', '.' ],
+                           { cwd: path.join(__dirname, 'napi_throw'),
+                           encoding: 'utf8' });
+tap.equal(build.stderr, '', 'No errors building addon');
+tap.equal(build.signal, null, 'Failed to build addon');
+tap.equal(build.status, 0, 'Failed to build addon');
+
+// Test catching the error does not trigger an UncaughtException report
+const common = require('./common.js');
+const report = require('../');
+const obj = require('./napi_throw/build/Release/test_napi_throw.node');
+tap.throws(obj.throwError);
+
+const reports = common.findReports(process.pid);
+tap.equals(reports, [], 'No reports should be generated');

--- a/test/test-napi-throw.js
+++ b/test/test-napi-throw.js
@@ -19,4 +19,4 @@ const obj = require('./napi_throw/build/Release/test_napi_throw.node');
 tap.throws(obj.throwError);
 
 const reports = common.findReports(process.pid);
-tap.equals(reports, [], 'No reports should be generated');
+tap.same(reports, [], 'No reports should be generated');


### PR DESCRIPTION
WIP.

Refs: https://github.com/nodejs/node-report/issues/131

Added test. Need to look at how to fix.