### PR TITLE
Update tap to version 14.3.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,4 @@ node-report*.txt
 npm-debug.log
 nodereport-*.tgz
 nodereport_test.log
+package-lock.json

--- a/.taprc
+++ b/.taprc
@@ -1,0 +1,1 @@
+esm: false

--- a/package.json
+++ b/package.json
@@ -24,6 +24,6 @@
     "url": "https://github.com/nodejs/node-report/issues"
   },
   "devDependencies": {
-    "tap": "~12.4.1"
+    "tap": "^14.3.1"
   }
 }

--- a/test/test-api-getreport.js
+++ b/test/test-api-getreport.js
@@ -17,6 +17,12 @@ if (process.argv[2] === 'child') {
                  'Checking no messages on stderr');
   const reportFiles = common.findReports(child.pid);
   tap.same(reportFiles, [], 'Checking no report files were written');
+
+  // tap with coverage enabled wraps the child so adjust expected command line
+  if (process.env['SPAWN_WRAP_SHIM_ROOT']) {
+    args.unshift('.*node');
+  }
+
   tap.test('Validating report content', (t) => {
     common.validateContent(child.stdout, t, { pid: child.pid,
       commandline: process.execPath + ' ' + args.join(' ')

--- a/test/test-fatal-error.js
+++ b/test/test-fatal-error.js
@@ -5,6 +5,10 @@ if (process.argv[2] === 'child') {
   require('../');
 
   const list = [];
+  // tap with coverage enabled installs signal handlers that prevents the
+  // fatal error causing the process to exit. Remove them.
+  process.removeAllListeners('SIGABRT');
+  process.removeAllListeners('SIGTRAP');
   while (true) {
     const record = new MyRecord();
     list.push(record);

--- a/test/test-signal.js
+++ b/test/test-signal.js
@@ -8,6 +8,10 @@ if (process.argv[2] === 'child') {
   // Exit on loss of parent process
   process.on('disconnect', () => process.exit(2));
 
+  // tap with coverage enabled installs signal handlers that prevents the
+  // signal from causing the process to exit. Remove them.
+  process.removeAllListeners('SIGTERM');
+
   function busyLoop() {
     var list = [];
     for (var i = 0; i < 1e10; i++) {


### PR DESCRIPTION
Fixes `npm audit` warning for `handlebars`:
```console
-bash-4.2$ npm audit

                       === npm audit security report ===

# Run  npm install --save-dev tap@14.4.0  to resolve 1 vulnerability
SEMVER WARNING: Recommended action is a potentially breaking change
┌───────────────┬──────────────────────────────────────────────────────────────┐
│ High          │ Prototype Pollution                                          │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Package       │ handlebars                                                   │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Dependency of │ tap [dev]                                                    │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Path          │ tap > nyc > istanbul-reports > handlebars                    │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ More info     │ https://npmjs.com/advisories/755                             │
└───────────────┴──────────────────────────────────────────────────────────────┘


found 1 high severity vulnerability in 578 scanned packages
  1 vulnerability requires semver-major dependency updates.
-bash-4.2$
```

Disable `esm` to allow tests to pass on Node.js 13 nightlies. (https://github.com/nodejs/node/issues/28294, https://github.com/standard-things/esm/issues/821).

`tap` now enables coverage by default and the update has exposed that a handful of tests have issues when run with coverage enabled (the same failures can be seen if run with the non-updated `tap` with `--coverage`). The main issue is that coverage is wrapping spawned child processes so that:
- The spawned process runs something else which runs the tests (this is hidden on the JavaScript side from the tests but not from `node-report` which reports the actual command line).
- Signal handlers are being installed by the wrapping which prevent the spawned process being terminated by signals (since the signals are now being caught).

The first commit contains changes to work around these issues. The alternative would be to disable coverage (which isn't as bad as it sounds given how little non-test/demo JavaScript is contained in this project).
