### PR TITLE
Fix npm audit warning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,4 @@ node-report*.txt
 npm-debug.log
 nodereport-*.tgz
 nodereport_test.log
+package-lock.json

--- a/package.json
+++ b/package.json
@@ -18,12 +18,12 @@
     "Richard Chamberlain <richard_chamberlain@uk.ibm.com> (https://github.com/rnchamberlain)"
   ],
   "scripts": {
-    "test": "tap --timeout=300 test/test*.js"
+    "test": "tap --no-esm --timeout=300 test/test*.js"
   },
   "bugs": {
     "url": "https://github.com/nodejs/node-report/issues"
   },
   "devDependencies": {
-    "tap": "~12.4.1"
+    "tap": "^12.7.0"
   }
 }


### PR DESCRIPTION
Update `tap` dependency to fix `npm audit` warning for `handlebars`.
Stay on `tap` version 12 to maintain Node.js 6 compatibility.
Disable "esm" to allow tests to pass on current Node.js master/13
nightlies.

Alternative to https://github.com/nodejs/node-report/pull/135 that keeps `tap` at version 12 to maintain 
compatibility with Node.js 6.