### PR TITLE
Add hostname to Machine line on AIX

### DIFF
--- a/src/node_report.cc
+++ b/src/node_report.cc
@@ -458,7 +458,14 @@ static void PrintVersionInformation(std::ostream& out) {
     if (libc_version != NULL) {
       out << "(glibc: " << (*libc_version)() << ")" << std::endl;
     }
+#if defined(_AIX)
+    char hn[256];
+    memset(hn,0,sizeof(hn));
+    gethostname(hn,sizeof(hn));
+    out <<  "\nMachine: " << hn << " " << os_info.nodename << " " << os_info.machine << "\n";
+#else
     out <<  "\nMachine: " << os_info.nodename << " " << os_info.machine << "\n";
+#endif
 #endif
   }
 #endif

--- a/test/common.js
+++ b/test/common.js
@@ -132,10 +132,6 @@ exports.validateContent = function validateContent(data, t, options) {
     t.match(nodeReportSection,
             new RegExp('Machine: ' + os.hostname(), 'i'), // ignore case on Windows
             'Checking machine name in report header section contains os.hostname()');
-  } else if (this.isAIX()) {
-    t.match(nodeReportSection,
-            new RegExp('Machine: ' + os.hostname().split('.')[0]), // truncate on AIX
-            'Checking machine name in report header section contains os.hostname()');
   } else {
     t.match(nodeReportSection,
             new RegExp('Machine: ' + os.hostname()),


### PR DESCRIPTION
On AIX the `nodename` returned by `uname` is not always consistent
with the hostname returned by `gethostname()`. Explicitly add the
hostname to the `Machine:` line in the report on AIX as we already
do for z/OS.