### PR TITLE
Escape version strings passed to regular expression matchers

### DIFF
--- a/test/common.js
+++ b/test/common.js
@@ -22,6 +22,10 @@ const REPORT_SECTIONS = [
 
 const reNewline = '(?:\\r*\\n)';
 
+const escapeRegex = (s) => {
+  return s.replace(/[\.+]/g, '\\$&');
+}
+
 exports.findReports = (pid) => {
   // Default filenames are of the form node-report.<date>.<time>.<pid>.<seq>.txt
   const format = '^node-report\\.\\d+\\.\\d+\\.' + pid + '\\.\\d+\\.txt$';
@@ -114,11 +118,11 @@ exports.validateContent = function validateContent(data, t, options) {
     if (c !== 'node') {
       if (expectedVersions.indexOf(c) === -1) {
         t.notMatch(nodeReportSection,
-                   new RegExp(c + ': ' + process.versions[c]),
+                   new RegExp(c + ': ' + escapeRegex(process.versions[c])),
                    'Node Report header section does not contain ' + c + ' version');
       } else {
         t.match(nodeReportSection,
-                new RegExp(c + ': ' + process.versions[c]),
+                new RegExp(c + ': ' + escapeRegex(process.versions[c])),
                 'Node Report header section contains expected ' + c + ' version');
       }
     }


### PR DESCRIPTION
Version strings in `process.versions` should be escaped before being
used to construct regular expressions. Fixes tests when run against
current Node.js master branch where OpenSSL has a `+` character in
its version string.

Refs: https://github.com/nodejs/citgm/issues/852#issuecomment-803261289